### PR TITLE
[F] Adjust header and share padding

### DIFF
--- a/components/content-blocks/ShareBlock/index.js
+++ b/components/content-blocks/ShareBlock/index.js
@@ -6,7 +6,7 @@ const SHARETHIS_PROPERTY = process.env.NEXT_PUBLIC_SHARETHIS_PROPERTY;
 export default function ShareContentBlock() {
   if (!SHARETHIS_PROPERTY) return null;
   return (
-    <Container>
+    <Container paddingSize="medium">
       <InlineShare />
     </Container>
   );

--- a/components/content-blocks/Text/index.js
+++ b/components/content-blocks/Text/index.js
@@ -3,7 +3,7 @@ import Container from "@/layout/Container";
 
 export default function TextContentBlock({ text }) {
   return (
-    <Container>
+    <Container paddingSize="medium">
       <div
         dangerouslySetInnerHTML={{ __html: text }}
         className="c-content-rte"

--- a/components/layout/Container/index.js
+++ b/components/layout/Container/index.js
@@ -12,16 +12,18 @@ export default function Container({
 }) {
   return (
     <Styled.Section
-      className={className}
+      className={classNames(className, {
+        [`l-pad-top-${paddingSize}`]: paddingSize !== "none",
+        [`l-pad-bottom-${paddingSize}`]: paddingSize !== "none",
+      })}
       $bgColor={bgColor}
-      $paddingSize={paddingSize}
       {...elAttributes}
     >
       <Styled.Inner
         className={classNames({
           [`${className}__inner`]: !!className,
         })}
-        width={width}
+        $width={width}
       >
         {children}
       </Styled.Inner>
@@ -40,7 +42,9 @@ Container.propTypes = {
   ]).isRequired,
   className: PropTypes.string,
   width: PropTypes.string,
-  paddingSize: "large" || "medium" || "small" || "none",
+  /** Applies padding utility class of the same name.
+   * Default is "large", "none" removes the class entirely */
+  paddingSize: PropTypes.oneOf(["large", "medium", "small", "none"]),
   elAttributes: PropTypes.shape({
     role: PropTypes.string,
     "aria-hidden": PropTypes.bool,

--- a/components/layout/Container/index.js
+++ b/components/layout/Container/index.js
@@ -1,47 +1,33 @@
 import PropTypes from "prop-types";
-import styled from "styled-components";
 import classNames from "classnames";
-import {
-  containerNarrow,
-  containerRegular,
-  PADDING_LARGE,
-  tokens,
-} from "@/styles/globalStyles";
+import * as Styled from "./styles";
 
 export default function Container({
   bgColor = "white",
   children,
   className,
   width = "narrow",
+  paddingSize = "large",
   elAttributes,
 }) {
   return (
-    <Section className={className} bgColor={bgColor} {...elAttributes}>
-      <Inner
+    <Styled.Section
+      className={className}
+      $bgColor={bgColor}
+      $paddingSize={paddingSize}
+      {...elAttributes}
+    >
+      <Styled.Inner
         className={classNames({
           [`${className}__inner`]: !!className,
         })}
         width={width}
       >
         {children}
-      </Inner>
-    </Section>
+      </Styled.Inner>
+    </Styled.Section>
   );
 }
-
-const Section = styled.section`
-  background-color: ${(p) => tokens[p.bgColor]};
-  padding-top: ${PADDING_LARGE};
-  padding-bottom: ${PADDING_LARGE};
-
-  + section {
-    padding-top: 0;
-  }
-`;
-
-const Inner = styled.div`
-  ${(p) => (p.width === "narrow" ? containerNarrow() : containerRegular())}
-`;
 
 Container.displayName = "Layout.Container";
 
@@ -54,6 +40,7 @@ Container.propTypes = {
   ]).isRequired,
   className: PropTypes.string,
   width: PropTypes.string,
+  paddingSize: "large" || "medium" || "small" || "none",
   elAttributes: PropTypes.shape({
     role: PropTypes.string,
     "aria-hidden": PropTypes.bool,

--- a/components/layout/Container/styles.js
+++ b/components/layout/Container/styles.js
@@ -1,0 +1,36 @@
+import styled from "styled-components";
+import {
+  containerNarrow,
+  containerRegular,
+  PADDING_LARGE,
+  PADDING_MEDIUM,
+  PADDING_SMALL,
+  tokens,
+} from "@/styles/globalStyles";
+
+function getPadding(padding) {
+  switch (padding) {
+    case "none":
+      return 0;
+    case "medium":
+      return PADDING_MEDIUM;
+    case "small":
+      return PADDING_SMALL;
+    default:
+      return PADDING_LARGE;
+  }
+}
+
+export const Section = styled.section`
+  background-color: ${(p) => tokens[p.$bgColor]};
+  padding-block-start: ${(p) => getPadding(p.$paddingSize)};
+  padding-block-end: ${(p) => getPadding(p.$paddingSize)};
+
+  + section {
+    padding-top: 0;
+  }
+`;
+
+export const Inner = styled.div`
+  ${(p) => (p.width === "narrow" ? containerNarrow() : containerRegular())}
+`;

--- a/components/layout/Container/styles.js
+++ b/components/layout/Container/styles.js
@@ -2,29 +2,11 @@ import styled from "styled-components";
 import {
   containerNarrow,
   containerRegular,
-  PADDING_LARGE,
-  PADDING_MEDIUM,
-  PADDING_SMALL,
   tokens,
 } from "@/styles/globalStyles";
 
-function getPadding(padding) {
-  switch (padding) {
-    case "none":
-      return 0;
-    case "medium":
-      return PADDING_MEDIUM;
-    case "small":
-      return PADDING_SMALL;
-    default:
-      return PADDING_LARGE;
-  }
-}
-
 export const Section = styled.section`
   background-color: ${(p) => tokens[p.$bgColor]};
-  padding-block-start: ${(p) => getPadding(p.$paddingSize)};
-  padding-block-end: ${(p) => getPadding(p.$paddingSize)};
 
   + section {
     padding-top: 0;
@@ -32,5 +14,5 @@ export const Section = styled.section`
 `;
 
 export const Inner = styled.div`
-  ${(p) => (p.width === "narrow" ? containerNarrow() : containerRegular())}
+  ${(p) => (p.$width === "narrow" ? containerNarrow() : containerRegular())}
 `;

--- a/components/templates/EventPage/index.js
+++ b/components/templates/EventPage/index.js
@@ -68,7 +68,7 @@ export default function EventPage({
     <Body {...bodyProps}>
       <Breadcrumbs breadcrumbs={[...customBreadcrumbs, pageLink]} />
       <Hero data={hero} />
-      <Container>
+      <Container paddingSize="medium">
         <div>
           {eventType?.[0]?.title && (
             <Pretitle>{eventType?.[0]?.title}</Pretitle>
@@ -83,7 +83,7 @@ export default function EventPage({
       </Container>
       <Share />
       {description && (
-        <Container>
+        <Container paddingSize="medium">
           <div
             className="c-content-rte"
             dangerouslySetInnerHTML={{ __html: description }}

--- a/components/templates/NewsPage/index.js
+++ b/components/templates/NewsPage/index.js
@@ -102,11 +102,11 @@ export default function NewsPage({
       <Hero data={hero} />
       <NewsDetail>
         <article>
-          <Container>
+          <Container paddingSize="medium">
             <div>
               <h1>{title}</h1>
               <Pretitle>{localizedDate}</Pretitle>
-              <Subtitle>{description}</Subtitle>
+              {description && <Subtitle>{description}</Subtitle>}
             </div>
           </Container>
           <Share />

--- a/components/templates/Page/index.js
+++ b/components/templates/Page/index.js
@@ -57,6 +57,8 @@ export default function Page({
   const isWideHeader =
     dynamicComponent === "galleryItems" || dynamicComponent === "slideshows";
 
+  const isMediumPadding = dynamicComponent === "none";
+
   const isGalleryHome = uri === "gallery";
   const isEventsPage = uri.split("/").includes("calendar");
 
@@ -92,6 +94,7 @@ export default function Page({
           bgColor="white"
           className="c-page-header"
           width={isWideHeader ? "regular" : "narrow"}
+          paddingSize={isMediumPadding ? "medium" : undefined}
         >
           <h1>{title}</h1>
           {isEventsPage && (

--- a/theme/styles/abstracts/_functions.scss
+++ b/theme/styles/abstracts/_functions.scss
@@ -24,6 +24,11 @@
   @return math.div(strip-unit($px), strip-unit($base)) + 0em;
 }
 
+// convert pt to em
+@function pt-to-em($pt, $base: variables.$font-size-base-desktop) {
+  @return math.div(strip-unit($pt) * 1.333, strip-unit($base)) + 0em;
+}
+
 // encode colors
 @function encode-color($string) {
   @if type-of($string) == "color" {

--- a/theme/styles/components/_content-rte.scss
+++ b/theme/styles/components/_content-rte.scss
@@ -5,6 +5,10 @@
     margin-top: 1rem;
   }
 
+  > *:first-child {
+    margin-block-start: 0;
+  }
+
   a:not([class^="c-"]) {
     color: functions.palette(turquoise50);
     text-decoration: none;
@@ -24,15 +28,17 @@
     padding-left: 0.5em;
   }
 
-  // these also have margin, so we've decreased padding accordingly.
   h1 {
-    padding-top: 5rem;
+    margin-block-start: functions.pt-to-em(144pt);
   }
 
-  h2,
+  h2 {
+    margin-block-start: functions.pt-to-em(40pt);
+  }
+
   h3,
   h4 {
-    padding-top: 2rem;
+    margin-block-start: functions.pt-to-em(20pt);
   }
 
   figcaption {

--- a/theme/styles/utility/_layout.scss
+++ b/theme/styles/utility/_layout.scss
@@ -15,19 +15,19 @@
 // Create a a padding class in each direction for each value in $padding-sizes map
 @each $name, $value in variables.$padding-sizes {
   .l-pad-top-#{$name} {
-    padding-top: $value;
+    padding-block-start: $value;
   }
 
   .l-pad-right-#{$name} {
-    padding-right: $value;
+    padding-inline-end: $value;
   }
 
   .l-pad-bottom-#{$name} {
-    padding-bottom: $value;
+    padding-block-end: $value;
   }
 
   .l-pad-left-#{$name} {
-    padding-left: $value;
+    padding-inline-start: $value;
   }
 }
 


### PR DESCRIPTION
- Adjusts header padding in RTE to style guide
- Adds optional paddingSize prop to Containers
- Adjusts share icon and header padding on news pages, event pages, text content elements, and non-dynamic pages to "medium" (40px)
- Resolves #16 and #18 

Needs a quick visual review by José before merge