### PR TITLE
[B] Github workflows have correct main branch refs for gcloud

### DIFF
--- a/.github/workflows/dev-pull-request.yaml
+++ b/.github/workflows/dev-pull-request.yaml
@@ -24,7 +24,7 @@ jobs:
 
     # gcloud CLI setup
     - name: Login to GCP
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         service_account_key: ${{ secrets.DEV_SA_KEY }}
         project_id: ${{ secrets.SV_PROJ_NAME }}
@@ -80,7 +80,7 @@ jobs:
 
     # gcloud CLI setup
     - name: Login to GCP
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         service_account_key: ${{ secrets.DEV_SA_KEY }}
         project_id: ${{ secrets.SV_PROJ_NAME }}

--- a/.github/workflows/dev-push.yaml
+++ b/.github/workflows/dev-push.yaml
@@ -18,7 +18,7 @@ jobs:
 
     # gcloud CLI setup
     - name: Login to GCP
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         service_account_key: ${{ secrets.DEV_SA_KEY }}
         project_id: ${{ secrets.SV_PROJ_NAME }}

--- a/.github/workflows/master-pr.yaml
+++ b/.github/workflows/master-pr.yaml
@@ -24,7 +24,7 @@ jobs:
 
     # gcloud CLI setup
     - name: Login to GCP
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         service_account_key: ${{ secrets.SKYVIEWER_INT_SERVICE_ACCOUNT }}
         project_id: edc-int-6c5e
@@ -97,7 +97,7 @@ jobs:
 
     # gcloud CLI setup
     - name: Login to GCP
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         service_account_key: ${{ secrets.SKYVIEWER_INT_SERVICE_ACCOUNT }}
         project_id: edc-int-6c5e

--- a/.github/workflows/master-push.yaml
+++ b/.github/workflows/master-push.yaml
@@ -18,7 +18,7 @@ jobs:
 
     # gcloud CLI setup
     - name: Login to GCP
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         service_account_key: ${{ secrets.SKYVIEWER_INT_SERVICE_ACCOUNT }}
         project_id: edc-int-6c5e

--- a/.github/workflows/prod-push.yaml
+++ b/.github/workflows/prod-push.yaml
@@ -20,7 +20,7 @@ jobs:
 
     # gcloud CLI setup
     - name: Login to GCP
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         service_account_key: ${{ secrets.PIPELINE_EPO_PROD_PROJECT }}
         project_id: edc-prod-eef0


### PR DESCRIPTION
Encoutering [error on build](https://github.com/lsst-epo/rubin-obs-client/runs/5649165156?check_suite_focus=true):
```
Error: On 2022-04-05, the default branch will be renamed from "master" to "main". Your action is currently pinned to "@master". Even though GitHub creates redirects for renamed branches, testing found that this rename breaks existing GitHub Actions workflows that are pinned to the old branch name.
```

Following suggestion:
```
We strongly advise updating your GitHub Action YAML from:

    uses: 'google-github-actions/setup-gcloud@master'

to:

    uses: 'google-github-actions/setup-gcloud@v0'
```

Seems like it's done the trick.