### PR TITLE
Fix prod deployments

### DIFF
--- a/.github/workflows/dev-pull-request.yaml
+++ b/.github/workflows/dev-pull-request.yaml
@@ -89,6 +89,10 @@ jobs:
         project_id: ${{ secrets.SV_PROJ_NAME }}
         export_default_credentials: true        
 
+    - name: Format version name
+      id: version_name
+      run: echo "version_name=$(echo \"${{ github.head_ref }}\" | tr -cd '[:alnum:]' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+      
     # Destruct!
     - name: Destroy version
       run: gcloud app versions delete ${{ env.version_name }} --service=default

--- a/.github/workflows/master-pr.yaml
+++ b/.github/workflows/master-pr.yaml
@@ -104,7 +104,11 @@ jobs:
       with:
         service_account_key: ${{ secrets.SKYVIEWER_INT_SERVICE_ACCOUNT }}
         project_id: edc-int-6c5e
-        export_default_credentials: true        
+        export_default_credentials: true     
+
+    - name: Format version name
+      id: version_name
+      run: echo "version_name=$(echo \"${{ github.head_ref }}\" | tr -cd '[:alnum:]' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV   
 
     # Destruct!
     - name: Destroy version

--- a/.github/workflows/prod-push.yaml
+++ b/.github/workflows/prod-push.yaml
@@ -1,7 +1,7 @@
-name: 'Rubin Obs Client to Prod GAE'
+name: 'Deploy Rubin Obs Client to Prod GAE'
 
 on:
-  create:
+  push:
     branches:
       - '!*'
     tags:


### PR DESCRIPTION
This changes the prod deployment trigger so that it will only trigger on pushes of tags that start with 'v' (e.g. v1.0.0)