### PR TITLE
[C] loosen URL locale checking

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -311,23 +311,16 @@ export const getCategoryGroup = (categories, group) => {
 };
 
 // LANGUAGE STUFF
-export function getSiteString(langData = "") {
+export function getSiteString(langData = "", asLangString = false) {
+  const enString = asLangString ? "en-US" : "default";
   if (Array.isArray(langData)) {
-    return langData[0] === "es" ? "es" : "default";
+    return langData[0] === "es" ? "es" : enString;
   } else {
-    return langData.includes("/es") || langData === "es" ? "es" : "default";
-  }
-}
-export function getLangString(langData = "") {
-  if (Array.isArray(langData)) {
-    return langData[0] === "es" ? "es" : "en-US";
-  } else {
-    return langData.includes("/es") || langData === "es" ? "es" : "en-US";
+    return langData.includes("/es") || langData === "es" ? "es" : enString;
   }
 }
 
 // DAM METADATA
-
 export const useDamAssetAsImage = (damAsset) => {
   if (!damAsset || damAsset.length === 0) {
     return null;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -315,14 +315,14 @@ export function getSiteString(langData = "") {
   if (Array.isArray(langData)) {
     return langData[0] === "es" ? "es" : "default";
   } else {
-    return langData.includes("/es/") || langData === "es" ? "es" : "default";
+    return langData.includes("/es") || langData === "es" ? "es" : "default";
   }
 }
 export function getLangString(langData = "") {
   if (Array.isArray(langData)) {
     return langData[0] === "es" ? "es" : "en-US";
   } else {
-    return langData.includes("/es/") || langData === "es" ? "es" : "en-US";
+    return langData.includes("/es") || langData === "es" ? "es" : "en-US";
   }
 }
 

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,6 +1,6 @@
 import Document, { Html, Head, Main, NextScript } from "next/document";
 import { ServerStyleSheet } from "styled-components";
-import { getLangString } from "@/lib/utils";
+import { getSiteString } from "@/lib/utils";
 
 const GOOGLE_APP_ID = process.env.NEXT_PUBLIC_GOOGLE_APP_ID;
 
@@ -20,7 +20,7 @@ class CustomDocument extends Document {
       const {
         query: { uriSegments },
       } = ctx;
-      const lang = getLangString(uriSegments);
+      const lang = getSiteString(uriSegments, true);
       return {
         ...initialProps,
         lang,


### PR DESCRIPTION
For JIRA: "EPO-7309 #IN-REVIEW #comment loosen URL locale checking"

News article previews on the homepage were not showing their localized text. The `entries` graphQL query was always setting `site` to `default` regardless of the locale set on the frontend. Issue was in the `getSiteString()` utility method, for non-array language data a simple `includes()` or typed value comparison was used. The `includes()` search string was `/es/` which will return true for any page prefixed with the `es` locale _except_ for the homepage which does not have a trailing slash.

To fix this, I loosened the search string to `/es` but since this is such a low level function I am concerned it may have unintended impact on other URLs. For example a URL string like `/article/escape-from-new-york` could return as a Spanish language site.

Two alternatives I can think of: 

- force a trailing slash with the router
- use something else in the `getSiteString()` method to make sure that `/es` is a valid match only on the homepage.