### PR TITLE
ES pages' previews fix

### DIFF
--- a/pages/[[...uriSegments]].js
+++ b/pages/[[...uriSegments]].js
@@ -82,6 +82,8 @@ export async function getStaticPaths() {
 }
 
 export async function getStaticProps({ params: { uriSegments }, previewData }) {
+  const PREVIEW_SLUG = process.env.NEXT_PREVIEW_SLUG;
+
   if (!process.env.IS_GITHUB_ACTION) {
     fs.readFile(".next/BUILD_ID", (err, text) => {
       if (err) {
@@ -104,12 +106,13 @@ export async function getStaticProps({ params: { uriSegments }, previewData }) {
   }
 
   const runId = Date.now().toString();
-  const site = getSiteString(uriSegments);
-  const isPreview = previewData && uriSegments[0] === "preview-in-craft-cms";
+  const isPreview = previewData && uriSegments[0] === PREVIEW_SLUG;
+  const site = getSiteString(isPreview ? previewData.uriSegments : uriSegments);
   let uri = CRAFT_HOMEPAGE_URI;
-
+  // N.B. Because previewToken presence is unreliable this workaround with a dedicated "preview uriSegments" is used.
+  // If previewToken becomes reliable, deprecate previewData.uriSegments in favor of always using the uriSegments in the query params
   if (isPreview) {
-    uri = previewData.uri;
+    uri = previewData.uriSegments.join("/");
   } else if (uriSegments && uriSegments.length) {
     uri = uriSegments.join("/");
   }

--- a/pages/api/preview.js
+++ b/pages/api/preview.js
@@ -2,10 +2,11 @@ import { isCraftPreview } from "@/helpers";
 import { getEntryDataByUid } from "@/api/entry";
 
 const preview = async (req, res) => {
+  const PREVIEW_SLUG = process.env.NEXT_PREVIEW_SLUG;
   const { query } = req;
   const isPreview = isCraftPreview(query);
+  // N.B. previewToken isn't consistently available
   const previewToken = query.token || undefined;
-
   if (!query.entryUid)
     return res
       .status(401)
@@ -26,25 +27,23 @@ const preview = async (req, res) => {
 
   // const { pathname } = new URL(entry.url.replace("/es/es", "/es"));
   const { uri } = entry;
-  const previewUri = `/preview-in-craft-cms/${uri}`;
+  // N.B. Because previewToken presence is unreliable, we're always redirecting to previewUri so real pages are never inadvertently updated.
+  // If a previewToken becomes reliable, inclusion of previewToken in the preview data should be enough (and could use real page uri as redirect)
+  const previewUri = `/${PREVIEW_SLUG}`;
 
-  if (previewToken) {
-    // Enable Preview Mode by setting the cookies
-    res.setPreviewData(
-      {
-        previewToken,
-        uri,
-      },
-      {
-        maxAge: 120,
-        path: previewUri,
-      }
-    );
-    // Redirect to the path from the fetched url
-    res.redirect(previewUri);
-  } else {
-    res.redirect(uri);
-  }
+  // Enable Preview Mode by setting the cookies
+  res.setPreviewData(
+    {
+      previewToken,
+      uriSegments: uri.split("/"),
+    },
+    {
+      maxAge: 120,
+      path: previewUri,
+    }
+  );
+  // Redirect to the path from the fetched url
+  res.redirect(previewUri);
 };
 
 export default preview;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4866,20 +4866,10 @@ camelize@^1.0.0:
   resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.1.tgz#89b7e16884056331a35d6b5ad064332c91daa6c3"
   integrity sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==
 
-caniuse-lite@^1.0.30001400:
-  version "1.0.30001441"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001441.tgz#987437b266260b640a23cd18fbddb509d7f69f3e"
-  integrity sha512-OyxRR4Vof59I3yGWXws6i908EtGbMzVUi3ganaZQHmydk1iwDhRnvaPG2WaR0KcqrDFKrxVZHULT396LEPhXfg==
-
-caniuse-lite@^1.0.30001406, caniuse-lite@^1.0.30001426:
-  version "1.0.30001429"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001429.tgz#70cdae959096756a85713b36dd9cb82e62325639"
-  integrity sha512-511ThLu1hF+5RRRt0zYCf2U2yRr9GPF6m5y90SBCWsvSoYoW7yAGlv/elyPaNfvGCkp6kj/KFZWU0BMA69Prsg==
-
-caniuse-lite@^1.0.30001449:
-  version "1.0.30001480"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001480.tgz#9bbd35ee44c2480a1e3a3b9f4496f5066817164a"
-  integrity sha512-q7cpoPPvZYgtyC4VaBSN0Bt+PJ4c4EYRf0DrduInOz2SkFpHD5p3LnvEpqBp7UnJn+8x1Ogl1s38saUxe+ihQQ==
+caniuse-lite@^1.0.30001400, caniuse-lite@^1.0.30001406, caniuse-lite@^1.0.30001426, caniuse-lite@^1.0.30001449:
+  version "1.0.30001481"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001481.tgz"
+  integrity sha512-KCqHwRnaa1InZBtqXzP98LPg0ajCVujMKjqKDhZEthIpAsJl/YEIa3YvXjGXPVqzZVguccuu7ga9KOE1J9rKPQ==
 
 case-sensitive-paths-webpack-plugin@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
page entry URIs with es successfully query entry data from provided uri, while using the same dedicated previewUri strategy EN page entries use.  Also mmoved the dedicated previewUri value into an ENV VAR called NEXT_PREVIEW_SLUG