### PR TITLE
[F] Charting lib

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -4,6 +4,7 @@ const tsConfigPathsPlugin = require("tsconfig-paths-webpack-plugin");
 const config = {
   stories: ["../components/**/*.stories.@(js|jsx|ts|tsx)"],
   addons: [
+    "@storybook/addon-a11y",
     "@storybook/addon-links",
     "@storybook/addon-essentials",
     "@storybook/addon-interactions",

--- a/components/charts/Bar/index.js
+++ b/components/charts/Bar/index.js
@@ -3,6 +3,9 @@ import * as Styled from "./styles";
 import Tooltip from "../Tooltip";
 import { useState } from "react";
 
+/**
+ * Individual bar with an accompanying tooltip.
+ */
 const Bar = ({
   height = 0,
   width = 8,
@@ -45,15 +48,6 @@ Bar.propTypes = {
   value: PropTypes.number,
   tooltipFormatter: PropTypes.func,
   showTooltips: PropTypes.bool,
-  // data: PropTypes.arrayOf(PropTypes.number).isRequired,
-  // xDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
-  // yDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
-  // xScale: PropTypes.func.isRequired,
-  // yScale: PropTypes.func.isRequired,
-  // ticks: PropTypes.number.isRequired,
-  // showTooltips: PropTypes.boolean,
-  // tooltipFormatter: PropTypes.func,
-  // labelledById: PropTypes.string,
 };
 
 export default Bar;

--- a/components/charts/Bar/index.js
+++ b/components/charts/Bar/index.js
@@ -1,0 +1,59 @@
+import PropTypes from "prop-types";
+import * as Styled from "./styles";
+import Tooltip from "../Tooltip";
+import { useState } from "react";
+
+const Bar = ({
+  height = 0,
+  width = 8,
+  x,
+  y,
+  value,
+  showTooltips = true,
+  tooltipFormatter,
+}) => {
+  const [isTooltipVisible, setTooltipVisible] = useState(false);
+
+  return (
+    <g
+      role="listitem"
+      onMouseEnter={() => showTooltips && setTooltipVisible(true)}
+      onMouseLeave={() => showTooltips && setTooltipVisible(false)}
+    >
+      <Styled.Bar
+        {...{ width, height, x, y }}
+        transform={`translate(-${width / 2} -${height})`}
+      />
+      {showTooltips && (
+        <Tooltip
+          y={y - height}
+          isVisible={isTooltipVisible}
+          {...{ x, value, tooltipFormatter }}
+        />
+      )}
+    </g>
+  );
+};
+
+Bar.displayName = "Charts.Bar";
+
+Bar.propTypes = {
+  height: PropTypes.number,
+  width: PropTypes.number,
+  x: PropTypes.number,
+  y: PropTypes.number,
+  value: PropTypes.number,
+  tooltipFormatter: PropTypes.func,
+  showTooltips: PropTypes.bool,
+  // data: PropTypes.arrayOf(PropTypes.number).isRequired,
+  // xDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
+  // yDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
+  // xScale: PropTypes.func.isRequired,
+  // yScale: PropTypes.func.isRequired,
+  // ticks: PropTypes.number.isRequired,
+  // showTooltips: PropTypes.boolean,
+  // tooltipFormatter: PropTypes.func,
+  // labelledById: PropTypes.string,
+};
+
+export default Bar;

--- a/components/charts/Bar/styles.js
+++ b/components/charts/Bar/styles.js
@@ -1,0 +1,7 @@
+import styled from "styled-components";
+
+export const Bar = styled.rect`
+  transform-origin: center bottom;
+  fill: #30e0e3;
+  cursor: pointer;
+`;

--- a/components/charts/BarData/index.js
+++ b/components/charts/BarData/index.js
@@ -1,0 +1,48 @@
+import PropTypes from "prop-types";
+import Bar from "../Bar";
+
+const BarData = ({
+  data = [],
+  xDomain,
+  yDomain,
+  xScale,
+  yScale,
+  ticks,
+  labelledById,
+  showTooltips,
+  tooltipFormatter,
+}) => {
+  const interval = (xDomain[1] - xDomain[0]) / (ticks - 1);
+
+  return (
+    <g role="list" aria-labelledby={labelledById}>
+      {data.map((value, i) => {
+        const height = yScale(yDomain[1] - value);
+        const x = xScale(xDomain[0] + interval * i);
+        const y = yScale(yDomain[0]);
+        return (
+          <Bar
+            {...{ height, x, y, value, showTooltips, tooltipFormatter }}
+            key={`${value}-${i}`}
+          />
+        );
+      })}
+    </g>
+  );
+};
+
+BarData.displayName = "Charts.BarData";
+
+BarData.propTypes = {
+  data: PropTypes.arrayOf(PropTypes.number).isRequired,
+  xDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
+  yDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
+  xScale: PropTypes.func.isRequired,
+  yScale: PropTypes.func.isRequired,
+  ticks: PropTypes.number.isRequired,
+  showTooltips: PropTypes.boolean,
+  tooltipFormatter: PropTypes.func,
+  labelledById: PropTypes.string,
+};
+
+export default BarData;

--- a/components/charts/ChartBase/index.js
+++ b/components/charts/ChartBase/index.js
@@ -6,6 +6,7 @@ const ChartBase = ({ children, className, width = 900, height = 300 }) => {
       preserveAspectRatio="xMidYMid meet"
       viewBox={`0 0 ${width} ${height}`}
       className={className}
+      style={{ minHeight: height, height: "100%" }}
     >
       {children}
     </svg>

--- a/components/charts/ChartBase/index.js
+++ b/components/charts/ChartBase/index.js
@@ -1,0 +1,24 @@
+import PropTypes from "prop-types";
+
+const ChartBase = ({ children, className, width = 900, height = 300 }) => {
+  return (
+    <svg
+      preserveAspectRatio="xMidYMid meet"
+      viewBox={`0 0 ${width} ${height}`}
+      className={className}
+    >
+      {children}
+    </svg>
+  );
+};
+
+ChartBase.displayName = "Charts.Base";
+
+ChartBase.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  width: PropTypes.number,
+  height: PropTypes.number,
+};
+
+export default ChartBase;

--- a/components/charts/ChartFigure/ChartFigure.stories.js
+++ b/components/charts/ChartFigure/ChartFigure.stories.js
@@ -1,0 +1,112 @@
+import ChartFigure from ".";
+import ChartBase from "../ChartBase";
+import XAxis from "../XAxis";
+import YAxis from "../YAxis";
+import BarData from "../BarData";
+import { getLinearScale } from "@/lib/utils";
+import LineData from "../LineData";
+
+const meta = {
+  component: ChartFigure,
+  argTypes: {},
+};
+export default meta;
+
+const Template = ({ ...args }) => {
+  const width = 900;
+  const height = 300;
+  const padding = 40;
+  const xDomain = [0, 24];
+  const tempDomain = [0, 50];
+  const xScale = getLinearScale(xDomain, [padding, width - padding]);
+  const tempScale = getLinearScale(tempDomain, [height - padding, 0]);
+
+  const dewPointData = [
+    6, 6, 5, 5, 4, 4, 3, 2.5, 2, 8, 11, 15, 19, 22, 24, 23, 19, 14, 12, 9, 8, 7,
+    6.5, 6,
+  ];
+
+  const tempData = [
+    25, 23, 20, 18, 17, 15, 13, 10, 8, 9, 11, 15, 18, 28, 34, 32, 27, 23, 21,
+    19, 15, 12, 14, 22,
+  ];
+
+  return (
+    <ChartFigure {...args}>
+      <ChartBase {...{ width, height }}>
+        <XAxis
+          {...{
+            xDomain,
+            yDomain: tempDomain,
+            xScale,
+            yScale: tempScale,
+            ticks: 24,
+            labelFormatter: (value) => {
+              if (value === 0 || value === 12 || value === 23) {
+                const date = new Date();
+                date.setHours(value);
+                date.setMinutes(0);
+
+                return date.toLocaleString("en-US", {
+                  timeStyle: "short",
+                  hourCycle: "h23",
+                });
+              } else {
+                return;
+              }
+            },
+            padding,
+          }}
+        />
+        <YAxis
+          {...{
+            xDomain,
+            yDomain: tempDomain,
+            xScale,
+            yScale: tempScale,
+            ticks: 5,
+            padding,
+            labelFormatter: (value) =>
+              Intl.NumberFormat("en-US", {
+                style: "unit",
+                unit: "celsius",
+              }).format(value),
+          }}
+        />
+        <LineData
+          {...{
+            xDomain,
+            yDomain: tempDomain,
+            xScale,
+            yScale: tempScale,
+            data: tempData,
+            ticks: 24,
+            padding,
+          }}
+        />
+        <BarData
+          {...{
+            xDomain,
+            yDomain: tempDomain,
+            xScale,
+            yScale: tempScale,
+            data: dewPointData,
+            ticks: 24,
+            padding,
+            tooltipFormatter: (value) =>
+              Intl.NumberFormat("en-US", {
+                style: "unit",
+                unit: "celsius",
+              }).format(value),
+          }}
+        />
+      </ChartBase>
+    </ChartFigure>
+  );
+};
+
+export const Primary = Template.bind({});
+
+Primary.args = {
+  caption: "Hourly Temperature & Dew Point report - Celsius degrees",
+};

--- a/components/charts/ChartFigure/ChartFigure.stories.js
+++ b/components/charts/ChartFigure/ChartFigure.stories.js
@@ -55,8 +55,6 @@ const PrimaryTemplate = ({ ...args }) => {
                   timeStyle: "short",
                   hourCycle: "h23",
                 });
-              } else {
-                return;
               }
             },
             padding,
@@ -140,7 +138,6 @@ const OverflowTemplate = ({ ...args }) => {
             labelFormatter: (value) => {
               const now = new Date();
               const nowOffset = 13;
-              console.log(now.getHours());
               const date = new Date();
               date.setHours(now.getHours() - nowOffset + value);
               date.setMinutes(0);

--- a/components/charts/ChartFigure/ChartFigure.stories.js
+++ b/components/charts/ChartFigure/ChartFigure.stories.js
@@ -3,8 +3,9 @@ import ChartBase from "../ChartBase";
 import XAxis from "../XAxis";
 import YAxis from "../YAxis";
 import BarData from "../BarData";
-import { getLinearScale } from "@/lib/utils";
 import LineData from "../LineData";
+import ChartLegend from "../Legend";
+import { getLinearScale } from "@/lib/utils";
 
 const meta = {
   component: ChartFigure,
@@ -12,7 +13,7 @@ const meta = {
 };
 export default meta;
 
-const Template = ({ ...args }) => {
+const PrimaryTemplate = ({ ...args }) => {
   const width = 900;
   const height = 300;
   const padding = 40;
@@ -20,6 +21,10 @@ const Template = ({ ...args }) => {
   const tempDomain = [0, 50];
   const xScale = getLinearScale(xDomain, [padding, width - padding]);
   const tempScale = getLinearScale(tempDomain, [height - padding, 0]);
+  const legends = [
+    { title: "Temperature", type: "line", id: "legendTemperature" },
+    { title: "Dew Point", type: "bar", id: "legendDewPoint" },
+  ];
 
   const dewPointData = [
     6, 6, 5, 5, 4, 4, 3, 2.5, 2, 8, 11, 15, 19, 22, 24, 23, 19, 14, 12, 9, 8, 7,
@@ -32,14 +37,13 @@ const Template = ({ ...args }) => {
   ];
 
   return (
-    <ChartFigure {...args}>
+    <ChartFigure {...args} legend={<ChartLegend legends={legends} />}>
       <ChartBase {...{ width, height }}>
         <XAxis
           {...{
             xDomain,
-            yDomain: tempDomain,
             xScale,
-            yScale: tempScale,
+            y: height - padding,
             ticks: 24,
             labelFormatter: (value) => {
               if (value === 0 || value === 12 || value === 23) {
@@ -82,6 +86,7 @@ const Template = ({ ...args }) => {
             data: tempData,
             ticks: 24,
             padding,
+            labelledById: "legendTemperature",
           }}
         />
         <BarData
@@ -93,6 +98,7 @@ const Template = ({ ...args }) => {
             data: dewPointData,
             ticks: 24,
             padding,
+            labelledById: "legendDewPoint",
             tooltipFormatter: (value) =>
               Intl.NumberFormat("en-US", {
                 style: "unit",
@@ -105,8 +111,87 @@ const Template = ({ ...args }) => {
   );
 };
 
-export const Primary = Template.bind({});
+const OverflowTemplate = ({ ...args }) => {
+  const width = 1800;
+  const height = 300;
+  const padding = 40;
+  const xDomain = [0, 24];
+  const humidityDomain = [0, 50];
+  const xScale = getLinearScale(xDomain, [padding, width - padding]);
+  const humidityScale = getLinearScale(humidityDomain, [height - padding, 0]);
+  const legends = [{ title: "Humidity", type: "bar", id: "legendHumidity" }];
+
+  const humidityData = [38, 35, 35, 34, 33, 32, 30, 30, 28, 28, 27, 26, 24, 29];
+
+  const percentageFormatter = (value) =>
+    Intl.NumberFormat("en-US", {
+      style: "percent",
+    }).format(value / 100);
+
+  return (
+    <ChartFigure {...args} legend={<ChartLegend legends={legends} />}>
+      <ChartBase {...{ width, height }}>
+        <XAxis
+          {...{
+            xDomain,
+            xScale,
+            y: height - padding,
+            ticks: 24,
+            labelFormatter: (value) => {
+              const now = new Date();
+              const nowOffset = 13;
+              console.log(now.getHours());
+              const date = new Date();
+              date.setHours(now.getHours() - nowOffset + value);
+              date.setMinutes(0);
+
+              return date.getHours() === now.getHours()
+                ? "NOW"
+                : date.toLocaleString("en-US", {
+                    timeStyle: "short",
+                    hourCycle: "h23",
+                  });
+            },
+            padding,
+          }}
+        />
+        <YAxis
+          {...{
+            xDomain,
+            yDomain: humidityDomain,
+            xScale,
+            yScale: humidityScale,
+            ticks: 5,
+            padding,
+            labelFormatter: percentageFormatter,
+          }}
+        />
+        <BarData
+          {...{
+            xDomain,
+            yDomain: humidityDomain,
+            xScale,
+            yScale: humidityScale,
+            data: humidityData,
+            ticks: 24,
+            padding,
+            labelledById: "Hourly humidity report - Humidity percentage",
+            tooltipFormatter: percentageFormatter,
+          }}
+        />
+      </ChartBase>
+    </ChartFigure>
+  );
+};
+
+export const Primary = PrimaryTemplate.bind({});
 
 Primary.args = {
   caption: "Hourly Temperature & Dew Point report - Celsius degrees",
+};
+
+export const Overflowing = OverflowTemplate.bind({});
+
+Overflowing.args = {
+  caption: "Hourly humidity report - Humidity percentage",
 };

--- a/components/charts/ChartFigure/index.js
+++ b/components/charts/ChartFigure/index.js
@@ -1,0 +1,20 @@
+import PropTypes from "prop-types";
+import * as Styled from "./styles";
+
+const ChartFigure = ({ caption, children }) => {
+  return (
+    <Styled.Figure>
+      <Styled.Caption>{caption}</Styled.Caption>
+      <Styled.Content>{children}</Styled.Content>
+    </Styled.Figure>
+  );
+};
+
+ChartFigure.displayName = "Charts.Figure";
+
+ChartFigure.propTypes = {
+  caption: PropTypes.string,
+  children: PropTypes.node,
+};
+
+export default ChartFigure;

--- a/components/charts/ChartFigure/index.js
+++ b/components/charts/ChartFigure/index.js
@@ -1,11 +1,12 @@
 import PropTypes from "prop-types";
 import * as Styled from "./styles";
 
-const ChartFigure = ({ caption, children }) => {
+const ChartFigure = ({ caption, children, legend }) => {
   return (
     <Styled.Figure>
       <Styled.Caption>{caption}</Styled.Caption>
       <Styled.Content>{children}</Styled.Content>
+      {legend}
     </Styled.Figure>
   );
 };
@@ -15,6 +16,7 @@ ChartFigure.displayName = "Charts.Figure";
 ChartFigure.propTypes = {
   caption: PropTypes.string,
   children: PropTypes.node,
+  legend: PropTypes.node,
 };
 
 export default ChartFigure;

--- a/components/charts/ChartFigure/styles.js
+++ b/components/charts/ChartFigure/styles.js
@@ -1,0 +1,15 @@
+import styled from "styled-components";
+
+export const Figure = styled.figure`
+  background-color: var(--turquoise85, #12726c);
+  border-radius: 10px;
+  color: var(--white, #fff);
+  padding: var(--PADDING_SMALL, 20px);
+`;
+export const Caption = styled.figcaption`
+  text-align: center;
+`;
+export const Content = styled.div`
+  overflow-x: auto;
+  position: relative;
+`;

--- a/components/charts/ChartFigure/styles.js
+++ b/components/charts/ChartFigure/styles.js
@@ -17,15 +17,19 @@ export const Content = styled.div`
   overflow-x: auto;
   position: relative;
 
-  scrollbar-color: var(--white, #fff) transparent;
+  scrollbar-color: var(--white, #fff) rgba(255, 255, 255, 0.2);
+  scrollbar-width: thin;
 
   &::-webkit-scrollbar {
     height: 8px;
-    background-color: transparent; /* or add it to the track */
+    background-clip: padding-box;
+    border-top: 3px solid transparent;
+    border-bottom: 3px solid transparent;
+    background-color: rgba(255, 255, 255, 0.5); /* or add it to the track */
   }
 
   &::-webkit-scrollbar-thumb {
     border-radius: 4px;
-    background: var(--white, #fff);
+    background-color: var(--white, #fff);
   }
 `;

--- a/components/charts/ChartFigure/styles.js
+++ b/components/charts/ChartFigure/styles.js
@@ -5,6 +5,10 @@ export const Figure = styled.figure`
   border-radius: 10px;
   color: var(--white, #fff);
   padding: var(--PADDING_SMALL, 20px);
+
+  & > * + * {
+    margin-block-start: var(--PADDING_SMALL, 20px);
+  }
 `;
 export const Caption = styled.figcaption`
   text-align: center;
@@ -12,4 +16,16 @@ export const Caption = styled.figcaption`
 export const Content = styled.div`
   overflow-x: auto;
   position: relative;
+
+  scrollbar-color: var(--white, #fff) transparent;
+
+  &::-webkit-scrollbar {
+    height: 8px;
+    background-color: transparent; /* or add it to the track */
+  }
+
+  &::-webkit-scrollbar-thumb {
+    border-radius: 4px;
+    background: var(--white, #fff);
+  }
 `;

--- a/components/charts/Legend/index.js
+++ b/components/charts/Legend/index.js
@@ -1,0 +1,35 @@
+import PropTypes from "prop-types";
+import * as Styled from "./styles";
+import { ColorSwatch } from "@rubin-epo/epo-react-lib";
+
+const colors = {
+  line: "#f9dc86",
+  bar: "#30e0e3",
+};
+
+const ChartLegend = ({ legends = [] }) => {
+  return (
+    <Styled.Legends>
+      {legends.map(({ title, type, id }) => (
+        <Styled.Legend>
+          <Styled.LegendColor color={colors[type]} />
+          <Styled.LegendTitle id={id}>{title}</Styled.LegendTitle>
+        </Styled.Legend>
+      ))}
+    </Styled.Legends>
+  );
+};
+
+ChartLegend.displayName = "Charts.Legend";
+
+ChartLegend.propTypes = {
+  legends: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string,
+      type: PropTypes.oneOf("line", "bar"),
+      id: PropTypes.string,
+    })
+  ),
+};
+
+export default ChartLegend;

--- a/components/charts/Legend/index.js
+++ b/components/charts/Legend/index.js
@@ -1,6 +1,5 @@
 import PropTypes from "prop-types";
 import * as Styled from "./styles";
-import { ColorSwatch } from "@rubin-epo/epo-react-lib";
 
 const colors = {
   line: "#f9dc86",
@@ -11,7 +10,7 @@ const ChartLegend = ({ legends = [] }) => {
   return (
     <Styled.Legends>
       {legends.map(({ title, type, id }) => (
-        <Styled.Legend>
+        <Styled.Legend key={id}>
           <Styled.LegendColor color={colors[type]} />
           <Styled.LegendTitle id={id}>{title}</Styled.LegendTitle>
         </Styled.Legend>

--- a/components/charts/Legend/styles.js
+++ b/components/charts/Legend/styles.js
@@ -1,0 +1,21 @@
+import styled from "styled-components";
+import { ColorSwatch } from "@rubin-epo/epo-react-lib";
+
+export const Legends = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--PADDING_SMALL, 20px);
+`;
+
+export const Legend = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1ch;
+`;
+
+export const LegendTitle = styled.span``;
+
+export const LegendColor = styled(ColorSwatch)`
+  border-color: var(--white, #fff);
+`;

--- a/components/charts/Legend/styles.js
+++ b/components/charts/Legend/styles.js
@@ -17,5 +17,7 @@ export const Legend = styled.div`
 export const LegendTitle = styled.span``;
 
 export const LegendColor = styled(ColorSwatch)`
-  border-color: var(--white, #fff);
+  > span {
+    border-color: var(--white, #fff);
+  }
 `;

--- a/components/charts/LineData/index.js
+++ b/components/charts/LineData/index.js
@@ -19,7 +19,7 @@ const LineData = ({
     return nextPoint;
   }, "");
 
-  return <Styled.Line points={points} />;
+  return <Styled.Line points={points} aria-labelledby={labelledById} />;
 };
 
 LineData.displayName = "Charts.LineData";

--- a/components/charts/LineData/index.js
+++ b/components/charts/LineData/index.js
@@ -1,0 +1,36 @@
+import PropTypes from "prop-types";
+import * as Styled from "./styles";
+
+const LineData = ({
+  data = [],
+  xDomain,
+  xScale,
+  yScale,
+  ticks,
+  labelledById,
+}) => {
+  const interval = (xDomain[1] - xDomain[0]) / (ticks - 1);
+
+  const points = data.reduce((prev, curr, i) => {
+    const nextPoint = `${prev} ${xScale(xDomain[0] + interval * i)},${yScale(
+      curr
+    )}`;
+
+    return nextPoint;
+  }, "");
+
+  return <Styled.Line points={points} />;
+};
+
+LineData.displayName = "Charts.LineData";
+
+LineData.propTypes = {
+  data: PropTypes.arrayOf(PropTypes.number).isRequired,
+  xDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
+  xScale: PropTypes.func.isRequired,
+  yScale: PropTypes.func.isRequired,
+  ticks: PropTypes.number.isRequired,
+  labelledById: PropTypes.string,
+};
+
+export default LineData;

--- a/components/charts/LineData/styles.js
+++ b/components/charts/LineData/styles.js
@@ -1,0 +1,7 @@
+import styled from "styled-components";
+
+export const Line = styled.polyline`
+  stroke-width: 4;
+  stroke: #f9dc86;
+  fill: none;
+`;

--- a/components/charts/Tooltip/index.js
+++ b/components/charts/Tooltip/index.js
@@ -1,0 +1,57 @@
+import { useRef, createElement } from "react";
+import PropTypes from "prop-types";
+import * as Styled from "./styles";
+
+const Tooltip = ({
+  value,
+  tooltipFormatter,
+  x,
+  y,
+  height = 16,
+  isVisible = false,
+}) => {
+  const label = tooltipFormatter ? tooltipFormatter(value) : value;
+  const width = label.length * 8;
+  const arrowWidth = 6;
+  const xCenter = x + width / 2;
+
+  return (
+    <Styled.Tooltip
+      transform={`translate(-${width / 2} -${height * 1.5})`}
+      opacity={isVisible ? 1 : 0}
+    >
+      <Styled.TooltipBackground
+        rx={4}
+        width={width}
+        height={height}
+        {...{ x, y }}
+      />
+      <Styled.TooltipArrow
+        points={`${xCenter - arrowWidth} ${y + height} ${
+          xCenter + arrowWidth
+        } ${y + height} ${xCenter} ${y + height + arrowWidth}`}
+      />
+      <Styled.TooltipText
+        width={width}
+        height={height}
+        x={xCenter}
+        y={y + height / 2}
+      >
+        {label}
+      </Styled.TooltipText>
+    </Styled.Tooltip>
+  );
+};
+
+Tooltip.displayName = "Charts.Tooltip";
+
+Tooltip.propTypes = {
+  value: PropTypes.number.isRequired,
+  tooltipFormatter: PropTypes.func,
+  x: PropTypes.number.isRequired,
+  y: PropTypes.number.isRequired,
+  height: PropTypes.number,
+  isVisible: PropTypes.bool,
+};
+
+export default Tooltip;

--- a/components/charts/Tooltip/index.js
+++ b/components/charts/Tooltip/index.js
@@ -1,4 +1,3 @@
-import { useRef, createElement } from "react";
 import PropTypes from "prop-types";
 import * as Styled from "./styles";
 

--- a/components/charts/Tooltip/styles.js
+++ b/components/charts/Tooltip/styles.js
@@ -1,0 +1,20 @@
+import styled from "styled-components";
+
+export const Tooltip = styled.g`
+  cursor: default;
+`;
+
+export const TooltipBackground = styled.rect`
+  fill: #dce0e3;
+`;
+
+export const TooltipText = styled.text`
+  color: var(--black, #000);
+  dominant-baseline: central;
+  font-size: 12px;
+  text-anchor: middle;
+`;
+
+export const TooltipArrow = styled.polygon`
+  fill: #dce0e3;
+`;

--- a/components/charts/Tooltip/styles.js
+++ b/components/charts/Tooltip/styles.js
@@ -10,6 +10,7 @@ export const TooltipBackground = styled.rect`
 
 export const TooltipText = styled.text`
   color: var(--black, #000);
+  fill: var(--black, #000);
   dominant-baseline: central;
   font-size: 12px;
   text-anchor: middle;

--- a/components/charts/XAxis/index.js
+++ b/components/charts/XAxis/index.js
@@ -1,0 +1,65 @@
+import PropTypes from "prop-types";
+import * as Styled from "./styles";
+
+const XAxis = ({
+  xDomain,
+  yDomain,
+  xScale,
+  yScale,
+  padding,
+  ticks,
+  labelFormatter,
+  labelledById,
+}) => {
+  const tickHeight = 5;
+  const valueInterval = (xDomain[1] - xDomain[0]) / ticks;
+  const positionInterval = (xDomain[1] - xDomain[0]) / (ticks - 1);
+  const axisTop = yScale(yDomain[0]);
+
+  const tickMap = Array.from(Array(ticks)).map((tick, i) => {
+    const value = xDomain[0] + valueInterval * i;
+    const label = labelFormatter ? labelFormatter(value) : value;
+    const position = xScale(xDomain[0] + positionInterval * i);
+
+    return { label, position };
+  });
+
+  return (
+    <g role="list" aria-labelledby={labelledById}>
+      <Styled.BaseLine
+        x1={xScale(xDomain[0]) - padding}
+        x2={xScale(xDomain[1]) + padding}
+        y1={axisTop}
+        y2={axisTop}
+      />
+      {tickMap.map(({ label, position }, i) => (
+        <g role="listitem" key={`${label}-${i}`}>
+          <Styled.Tick
+            x1={position}
+            x2={position}
+            y1={axisTop}
+            y2={axisTop + tickHeight}
+          />
+          <Styled.TickLabel x={position} y={axisTop + tickHeight * 2}>
+            {label}
+          </Styled.TickLabel>
+        </g>
+      ))}
+    </g>
+  );
+};
+
+XAxis.displayName = "Charts.XAxis";
+
+XAxis.propTypes = {
+  xDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
+  yDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
+  xScale: PropTypes.func.isRequired,
+  yScale: PropTypes.func.isRequired,
+  padding: PropTypes.number.isRequired,
+  ticks: PropTypes.number.isRequired,
+  labelFormatter: PropTypes.func,
+  labelledById: PropTypes.string,
+};
+
+export default XAxis;

--- a/components/charts/XAxis/index.js
+++ b/components/charts/XAxis/index.js
@@ -3,9 +3,8 @@ import * as Styled from "./styles";
 
 const XAxis = ({
   xDomain,
-  yDomain,
   xScale,
-  yScale,
+  y = 0,
   padding,
   ticks,
   labelFormatter,
@@ -14,7 +13,6 @@ const XAxis = ({
   const tickHeight = 5;
   const valueInterval = (xDomain[1] - xDomain[0]) / ticks;
   const positionInterval = (xDomain[1] - xDomain[0]) / (ticks - 1);
-  const axisTop = yScale(yDomain[0]);
 
   const tickMap = Array.from(Array(ticks)).map((tick, i) => {
     const value = xDomain[0] + valueInterval * i;
@@ -29,18 +27,13 @@ const XAxis = ({
       <Styled.BaseLine
         x1={xScale(xDomain[0]) - padding}
         x2={xScale(xDomain[1]) + padding}
-        y1={axisTop}
-        y2={axisTop}
+        y1={y}
+        y2={y}
       />
       {tickMap.map(({ label, position }, i) => (
         <g role="listitem" key={`${label}-${i}`}>
-          <Styled.Tick
-            x1={position}
-            x2={position}
-            y1={axisTop}
-            y2={axisTop + tickHeight}
-          />
-          <Styled.TickLabel x={position} y={axisTop + tickHeight * 2}>
+          <Styled.Tick x1={position} x2={position} y1={y} y2={y + tickHeight} />
+          <Styled.TickLabel x={position} y={y + tickHeight * 2}>
             {label}
           </Styled.TickLabel>
         </g>
@@ -53,9 +46,8 @@ XAxis.displayName = "Charts.XAxis";
 
 XAxis.propTypes = {
   xDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
-  yDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
   xScale: PropTypes.func.isRequired,
-  yScale: PropTypes.func.isRequired,
+  y: PropTypes.number,
   padding: PropTypes.number.isRequired,
   ticks: PropTypes.number.isRequired,
   labelFormatter: PropTypes.func,

--- a/components/charts/XAxis/styles.js
+++ b/components/charts/XAxis/styles.js
@@ -1,0 +1,17 @@
+import styled from "styled-components";
+
+export const BaseLine = styled.line`
+  stroke: var(--white, #fff);
+`;
+
+export const Tick = styled.line`
+  stroke: var(--white, #fff);
+  stroke-width: 2;
+`;
+
+export const TickLabel = styled.text`
+  alignment-baseline: hanging;
+  dominant-baseline: hanging;
+  font-size: 14px;
+  text-anchor: middle;
+`;

--- a/components/charts/YAxis/index.js
+++ b/components/charts/YAxis/index.js
@@ -17,7 +17,6 @@ const YAxis = ({
 
   const tickMap = Array.from(Array(ticks)).map((tick, i) => {
     const value = yDomain[0] + interval * (i + 1);
-    console.log(value);
     const label = labelFormatter ? labelFormatter(value) : value;
     const labelPosition = secondary
       ? xScale(xDomain[1]) + padding

--- a/components/charts/YAxis/index.js
+++ b/components/charts/YAxis/index.js
@@ -1,0 +1,70 @@
+import PropTypes from "prop-types";
+import * as Styled from "./styles";
+
+const YAxis = ({
+  xDomain,
+  yDomain,
+  xScale,
+  yScale,
+  padding,
+  ticks,
+  labelFormatter,
+  labelledById,
+  showGridLines = true,
+  secondary = false,
+}) => {
+  const interval = (yDomain[1] - yDomain[0]) / ticks;
+
+  const tickMap = Array.from(Array(ticks)).map((tick, i) => {
+    const value = yDomain[0] + interval * (i + 1);
+    console.log(value);
+    const label = labelFormatter ? labelFormatter(value) : value;
+    const labelPosition = secondary
+      ? xScale(xDomain[1]) + padding
+      : xScale(xDomain[0]) - padding;
+    const position = yScale(value);
+
+    return { label, position, labelPosition };
+  });
+
+  return (
+    <g role="list" aria-labelledby={labelledById}>
+      {tickMap.map(({ label, labelPosition, position }, i) => (
+        <g role="listitem" key={`${label}-${i}`}>
+          {showGridLines && (
+            <Styled.GridLine
+              x1={xScale(xDomain[0]) - padding}
+              x2={xScale(xDomain[1]) + padding}
+              y1={position}
+              y2={position}
+            />
+          )}
+          <Styled.GridLineLabel
+            x={labelPosition}
+            y={position + 5}
+            textAnchor={secondary ? "end" : "start"}
+          >
+            {label}
+          </Styled.GridLineLabel>
+        </g>
+      ))}
+    </g>
+  );
+};
+
+YAxis.displayName = "Charts.YAxis";
+
+YAxis.propTypes = {
+  xDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
+  yDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
+  xScale: PropTypes.func.isRequired,
+  yScale: PropTypes.func.isRequired,
+  padding: PropTypes.number.isRequired,
+  ticks: PropTypes.number.isRequired,
+  labelFormatter: PropTypes.func,
+  labelledById: PropTypes.string,
+  showGridLines: PropTypes.bool,
+  secondary: PropTypes.bool,
+};
+
+export default YAxis;

--- a/components/charts/YAxis/styles.js
+++ b/components/charts/YAxis/styles.js
@@ -1,0 +1,11 @@
+import styled from "styled-components";
+
+export const GridLine = styled.line`
+  stroke: var(--white, #fff);
+`;
+
+export const GridLineLabel = styled.text`
+  alignment-baseline: mathematical;
+  dominant-baseline: mathematical;
+  font-size: 10px;
+`;

--- a/components/charts/index.js
+++ b/components/charts/index.js
@@ -1,0 +1,2 @@
+export { default as ChartBase } from "./ChartBase";
+export { default as ChartFigure } from "./ChartFigure";

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -4,6 +4,7 @@
     "paths": {
       "@/lib/*": ["lib/*"],
       "@/api/*": ["lib/api/*"],
+      "@/charts/*": ["charts/*"],
       "@/components/*": ["components/*"],
       "@/content-blocks": ["components/content-blocks"],
       "@/dynamic/*": ["components/dynamic/*"],

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,6 +4,13 @@ import GlobalDataContext from "@/contexts/GlobalData";
 import { useDataList } from "@/api/entries";
 import debounce from "lodash/debounce";
 
+export const getLinearScale = (domain, range) => {
+  const [dMin, dMax] = domain;
+  const [rMin, rMax] = range;
+
+  return (value) => (value / (dMax - dMin)) * (rMax - rMin) + rMin;
+};
+
 function nearestOdd(value) {
   return 2 * Math.round(value / 2) - 1;
 }

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-transform-react-jsx": "^7.18.6",
     "@rushstack/eslint-patch": "^1.1.4",
+    "@storybook/addon-a11y": "^7.0.8",
     "@storybook/addon-essentials": "^7.0.6",
     "@storybook/addon-interactions": "^7.0.6",
     "@storybook/addon-links": "^7.0.6",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@castiron/style-mixins": "^1.0.6",
     "@headlessui/react": "^1.6.6",
     "@popperjs/core": "^2.11.5",
-    "@rubin-epo/epo-react-lib": "^1.2.4",
+    "@rubin-epo/epo-react-lib": "^1.2.5",
     "add": "^2.0.6",
     "classnames": "^2.3.1",
     "feed": "^4.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2367,10 +2367,10 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
   integrity sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==
 
-"@rubin-epo/epo-react-lib@^1.2.4":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@rubin-epo/epo-react-lib/-/epo-react-lib-1.2.4.tgz#5f852b58ff7881de0d72908164d17094fd22a8ce"
-  integrity sha512-0LdDmXiSfpY2gL7eto5xzEbn1ue51M5Kk1m79F68GUrXbd2xBhiemg52T0Li6+IEP0QpWMlpP27Re0gdRFtvzw==
+"@rubin-epo/epo-react-lib@^1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@rubin-epo/epo-react-lib/-/epo-react-lib-1.2.5.tgz#7100072c15cb3c9eca80fb9cf6e3970ddc22b341"
+  integrity sha512-jGZR5I0bdwAzdq105ZpusyB2e+x+peozrZUvBL98Fna67lxd04nYN3gS5anFaSMSbV4sXGQKdy2VLpGySKnzFw==
   dependencies:
     flickity "^3.0.0"
     react-player "^2.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2408,6 +2408,25 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@storybook/addon-a11y@^7.0.8":
+  version "7.0.8"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-a11y/-/addon-a11y-7.0.8.tgz#4784d2d0b3575f98d606bc122cacfe6ddb94bc62"
+  integrity sha512-TjhRTW4xXo+8oYGKbZ5NSX7i72ZNC5OD2VLmn8ywSGHAV/UOFRG5YSs9GeMPKsvGRcsztytj1D/Pl5LWL3VwlQ==
+  dependencies:
+    "@storybook/addon-highlight" "7.0.8"
+    "@storybook/channels" "7.0.8"
+    "@storybook/client-logger" "7.0.8"
+    "@storybook/components" "7.0.8"
+    "@storybook/core-events" "7.0.8"
+    "@storybook/global" "^5.0.0"
+    "@storybook/manager-api" "7.0.8"
+    "@storybook/preview-api" "7.0.8"
+    "@storybook/theming" "7.0.8"
+    "@storybook/types" "7.0.8"
+    axe-core "^4.2.0"
+    lodash "^4.17.21"
+    react-resize-detector "^7.1.2"
+
 "@storybook/addon-actions@7.0.6":
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-7.0.6.tgz#96f37c687769f282d4746de07eda8a305d4b21ad"
@@ -2518,6 +2537,15 @@
     "@storybook/core-events" "7.0.6"
     "@storybook/global" "^5.0.0"
     "@storybook/preview-api" "7.0.6"
+
+"@storybook/addon-highlight@7.0.8":
+  version "7.0.8"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-highlight/-/addon-highlight-7.0.8.tgz#884d5ef03559d711f88504d5662f5d91cd6ebcb0"
+  integrity sha512-d26jo7/Z1PIzZH+cE5E6jZ3yKgKFOPZNfylz2Gpg8jD2gV91Nk30ursl4nEJToEsEe2JkSdae4Qm59vCXbWcNw==
+  dependencies:
+    "@storybook/core-events" "7.0.8"
+    "@storybook/global" "^5.0.0"
+    "@storybook/preview-api" "7.0.8"
 
 "@storybook/addon-interactions@^7.0.6":
   version "7.0.6"
@@ -2735,6 +2763,18 @@
     qs "^6.10.0"
     telejson "^7.0.3"
 
+"@storybook/channel-postmessage@7.0.8":
+  version "7.0.8"
+  resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-7.0.8.tgz#8246237596381ae2f1a086a99d84d7e41c4a5ec8"
+  integrity sha512-op/SB2Tg66bxS4DHOhrSVja7Xdp8aiWIJ47vygSq31nqpwv5auCTptOrcdzTikOjH+4dKfTGxTx6Z5g065tuiQ==
+  dependencies:
+    "@storybook/channels" "7.0.8"
+    "@storybook/client-logger" "7.0.8"
+    "@storybook/core-events" "7.0.8"
+    "@storybook/global" "^5.0.0"
+    qs "^6.10.0"
+    telejson "^7.0.3"
+
 "@storybook/channel-websocket@7.0.6":
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@storybook/channel-websocket/-/channel-websocket-7.0.6.tgz#281663622eb1deb6c73271ddf5bb1a33c91afdaf"
@@ -2749,6 +2789,11 @@
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-7.0.6.tgz#c025eeb45072a89b82e111bea021b09f4cc80b96"
   integrity sha512-+34cVmrXZ3lb1s5tDK+OWd5HLtEPSUMas0VKFJ0k9LBpFlVl9aiCZBJRvSYmWL7beauUfa+HSmJgjlD6228ChQ==
+
+"@storybook/channels@7.0.8":
+  version "7.0.8"
+  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-7.0.8.tgz#35aca088b17873f9519ce4d442b03f9ecca2ea6b"
+  integrity sha512-z8W4r8te/EiEDfk8qaxmjwMcKMe+x12leWEwtyz6e9XI0Q4qTk17dDtq/XZ5Ab2Ks4VSvWRu1e/QURiVpjbo2Q==
 
 "@storybook/cli@7.0.6":
   version "7.0.6"
@@ -2809,6 +2854,13 @@
   dependencies:
     "@storybook/global" "^5.0.0"
 
+"@storybook/client-logger@7.0.8":
+  version "7.0.8"
+  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-7.0.8.tgz#9f5a0fd4fdbb179458c310c84ed4e3d5c5b3c47a"
+  integrity sha512-UuyX57Jzn8L0QOhDPBA/v9UqIGCtFKqtaS23mNNNDoc1X3u+boULNgqWGD84F2U7JWg2xNopIJvjQxhH30/Jhw==
+  dependencies:
+    "@storybook/global" "^5.0.0"
+
 "@storybook/codemod@7.0.6":
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@storybook/codemod/-/codemod-7.0.6.tgz#e5904c72261422b21da6ec3ef88d32daa4e96e64"
@@ -2838,6 +2890,20 @@
     "@storybook/global" "^5.0.0"
     "@storybook/theming" "7.0.6"
     "@storybook/types" "7.0.6"
+    memoizerific "^1.11.3"
+    use-resize-observer "^9.1.0"
+    util-deprecate "^1.0.2"
+
+"@storybook/components@7.0.8":
+  version "7.0.8"
+  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-7.0.8.tgz#4eafb70767995594209e88068a5ff185392164d0"
+  integrity sha512-eBY+uZE+0dHwvUTQHa/GNzAexEg1Sqhzyu+NTWx2mAzNzXBaoBQ1wz33sXQFWQZA6Bv/yritPmfo6470f8/AFg==
+  dependencies:
+    "@storybook/client-logger" "7.0.8"
+    "@storybook/csf" "^0.1.0"
+    "@storybook/global" "^5.0.0"
+    "@storybook/theming" "7.0.8"
+    "@storybook/types" "7.0.8"
     memoizerific "^1.11.3"
     use-resize-observer "^9.1.0"
     util-deprecate "^1.0.2"
@@ -2879,6 +2945,11 @@
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-7.0.6.tgz#f3b4876cb9003a6bbdbd9602d017e2b37ec86f78"
   integrity sha512-kGrtjlYtjd4iTVk+Phb4CymZaVkB+MGscKAgcO8gfgJ/Q/gq8HQLVZSIzeoCDcDSHOGlBzbg2WVtdHIHhCKlOQ==
+
+"@storybook/core-events@7.0.8":
+  version "7.0.8"
+  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-7.0.8.tgz#438d16aad23790b2b50b00f5a345b930fa9d91de"
+  integrity sha512-CQJs3PKQ8HJmMe7kzYy2bWz3hw5d8myAtO5LAgvPHKsVqAZ0R+rN4lXlcPNWf/x3tb8JizDJpPgTCBdOBb+tkg==
 
 "@storybook/core-server@7.0.6":
   version "7.0.6"
@@ -3031,6 +3102,27 @@
     telejson "^7.0.3"
     ts-dedent "^2.0.0"
 
+"@storybook/manager-api@7.0.8":
+  version "7.0.8"
+  resolved "https://registry.yarnpkg.com/@storybook/manager-api/-/manager-api-7.0.8.tgz#f212f5edecebebc0b025c1a2afafba7b99acb877"
+  integrity sha512-5z5ZuijtlMhT/VHmwJnzA4y6W3xfSVQ887wn93GQG7G8xMAMADODOdJK2e10jgto8OPoT8GyDHXCBvGh2oIJzQ==
+  dependencies:
+    "@storybook/channels" "7.0.8"
+    "@storybook/client-logger" "7.0.8"
+    "@storybook/core-events" "7.0.8"
+    "@storybook/csf" "^0.1.0"
+    "@storybook/global" "^5.0.0"
+    "@storybook/router" "7.0.8"
+    "@storybook/theming" "7.0.8"
+    "@storybook/types" "7.0.8"
+    dequal "^2.0.2"
+    lodash "^4.17.21"
+    memoizerific "^1.11.3"
+    semver "^7.3.7"
+    store2 "^2.14.2"
+    telejson "^7.0.3"
+    ts-dedent "^2.0.0"
+
 "@storybook/manager@7.0.6":
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@storybook/manager/-/manager-7.0.6.tgz#5342a926c43cb1c36ee9fde742ec457e95cf3afa"
@@ -3141,6 +3233,27 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
+"@storybook/preview-api@7.0.8":
+  version "7.0.8"
+  resolved "https://registry.yarnpkg.com/@storybook/preview-api/-/preview-api-7.0.8.tgz#748da87db2a62f44fbcc6b833043b3956096c67a"
+  integrity sha512-+/nhvNo7ML6bPnFYJRH/+mwU/sVJbIGhxFy4r+4Omxaw4aKhs8T0eVijGE2KOahRKG3qUCYV1CaTqmnlbcXgbw==
+  dependencies:
+    "@storybook/channel-postmessage" "7.0.8"
+    "@storybook/channels" "7.0.8"
+    "@storybook/client-logger" "7.0.8"
+    "@storybook/core-events" "7.0.8"
+    "@storybook/csf" "^0.1.0"
+    "@storybook/global" "^5.0.0"
+    "@storybook/types" "7.0.8"
+    "@types/qs" "^6.9.5"
+    dequal "^2.0.2"
+    lodash "^4.17.21"
+    memoizerific "^1.11.3"
+    qs "^6.10.0"
+    synchronous-promise "^2.0.15"
+    ts-dedent "^2.0.0"
+    util-deprecate "^1.0.2"
+
 "@storybook/preview@7.0.6":
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@storybook/preview/-/preview-7.0.6.tgz#8476ad2c42e1cdcf2ced5741f438316f6bd95e4c"
@@ -3200,6 +3313,15 @@
     memoizerific "^1.11.3"
     qs "^6.10.0"
 
+"@storybook/router@7.0.8":
+  version "7.0.8"
+  resolved "https://registry.yarnpkg.com/@storybook/router/-/router-7.0.8.tgz#58d860bf4b55932062637fdd03887c210d1b7fbd"
+  integrity sha512-aVTBGLN84tGLsHTX+SbekyZPN9In3eaf7xCtssi5PYVezpV5y1/KrOsCk9sztuhfzoTkEtB0WFBVKpKdH9jBtQ==
+  dependencies:
+    "@storybook/client-logger" "7.0.8"
+    memoizerific "^1.11.3"
+    qs "^6.10.0"
+
 "@storybook/store@7.0.6":
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@storybook/store/-/store-7.0.6.tgz#95a8c04ef9477d792d9d3ee96bd4e5c175645f63"
@@ -3244,12 +3366,32 @@
     "@storybook/global" "^5.0.0"
     memoizerific "^1.11.3"
 
+"@storybook/theming@7.0.8":
+  version "7.0.8"
+  resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-7.0.8.tgz#7f785473b47743bb74bd0b068acb550f421ab603"
+  integrity sha512-nU4j/QrobGxPgAg34ieIswkDITC/eHFJqzMfnyc3EhA8P60YNFWjzQlDlkDA5jG/6xiakihLWH2pzLhPDdME5g==
+  dependencies:
+    "@emotion/use-insertion-effect-with-fallbacks" "^1.0.0"
+    "@storybook/client-logger" "7.0.8"
+    "@storybook/global" "^5.0.0"
+    memoizerific "^1.11.3"
+
 "@storybook/types@7.0.6":
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@storybook/types/-/types-7.0.6.tgz#3bdc0f4ade0c21548a3b6423b64c8ae1e797ba35"
   integrity sha512-dFASQxzvldU2Nx/eJG+oL4wCchUWAKOmOSYJYhKgtGpx99oXOiWUyC0SgCpTveBJ7AppoiseyasQ9Gd/Ccycdw==
   dependencies:
     "@storybook/channels" "7.0.6"
+    "@types/babel__core" "^7.0.0"
+    "@types/express" "^4.7.0"
+    file-system-cache "^2.0.0"
+
+"@storybook/types@7.0.8":
+  version "7.0.8"
+  resolved "https://registry.yarnpkg.com/@storybook/types/-/types-7.0.8.tgz#28764060f5ad89137bec0815e41f0bf4a1de801d"
+  integrity sha512-x83vL/TzBlv21nHuP35c+z4AUjHSY9G7NpZLTZ/5REcuXbeIfhjGOAyeUHB4lXhPXxsOlq3wHiQippB7bSJeeQ==
+  dependencies:
+    "@storybook/channels" "7.0.8"
     "@types/babel__core" "^7.0.0"
     "@types/express" "^4.7.0"
     file-system-cache "^2.0.0"
@@ -4415,6 +4557,11 @@ available-typed-arrays@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
+
+axe-core@^4.2.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.7.0.tgz#34ba5a48a8b564f67e103f0aa5768d76e15bbbbf"
+  integrity sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==
 
 axe-core@^4.4.3:
   version "4.5.1"
@@ -10733,6 +10880,13 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
+
+react-resize-detector@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-7.1.2.tgz#8ef975dd8c3d56f9a5160ac382ef7136dcd2d86c"
+  integrity sha512-zXnPJ2m8+6oq9Nn8zsep/orts9vQv3elrpA+R8XTcW7DVVUJ9vwDwMXaBtykAYjMnkCIaOoK9vObyR7ZgFNlOw==
+  dependencies:
+    lodash "^4.17.21"
 
 react-share@^4.4.1:
   version "4.4.1"


### PR DESCRIPTION
- Added charting tools to support Summit Status Dashboard, no new dependencies pulled in for charting. Dependency change comes from adding Storybook a11y addon.
- The ChartFigure component is the only component with a story and contains two examples: one with bar and line graph data, and the other with bar graph data but overflowing the parent container. The overflow occurs automatically and is based on the specified height of the chart.
- There is no singular "Chart" component where a config and some data are passed resulting in a chart; rather these are components intended to be assembled as needed into containers for charts. They may be mixed, matched, and enhanced with bespoke components as-needed, there is no prescribed "Bar Graph" or "Line Graph".