### PR TITLE
[EPO-8165] Loading Spinner implementations

### DIFF
--- a/components/atomic/Loader/index.js
+++ b/components/atomic/Loader/index.js
@@ -1,0 +1,9 @@
+import * as Styled from "./styles";
+
+function Loader(props) {
+  return <Styled.Loader {...props} />;
+}
+
+Loader.displayName = "Atomic.Loader";
+
+export default Loader;

--- a/components/atomic/Loader/styles.js
+++ b/components/atomic/Loader/styles.js
@@ -1,0 +1,8 @@
+import styled from "styled-components";
+import { CircularLoader } from "@rubin-epo/epo-react-lib";
+
+export const Loader = styled(CircularLoader)`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;

--- a/components/content-blocks/GridBlock/CarouselGrid/index.js
+++ b/components/content-blocks/GridBlock/CarouselGrid/index.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import striptags from "striptags";
 import chunk from "lodash/chunk";
 import Tile from "@/atomic/Tile";
+import Loader from "@/atomic/Loader";
 import { Grid } from "@rubin-epo/epo-react-lib";
 import { normalizeItemData, useList } from "@/lib/utils";
 import * as Styled from "./styles";
@@ -19,7 +20,7 @@ function CarouselGrid({
   // get manually-curated data first
   const curatedItems = normalizeItemData(items);
 
-  const { data } = useList({
+  const { data, isLoading } = useList({
     limit,
     listTypeId,
     section,
@@ -64,6 +65,7 @@ function CarouselGrid({
     );
   }
 
+  if (isLoading) return <Loader speed="fast" isVisible />;
   if (!allItems?.length) return null;
 
   if (allItems.length <= 3)

--- a/components/content-blocks/GridBlock/MainGrid.js
+++ b/components/content-blocks/GridBlock/MainGrid.js
@@ -3,6 +3,7 @@ import striptags from "striptags";
 import { normalizeItemData, useList } from "@/lib/utils";
 import { Grid } from "@rubin-epo/epo-react-lib";
 import Tile from "@/atomic/Tile";
+import Loader from "@/atomic/Loader";
 
 const MainGrid = ({ items = [], limit, listTypeId, sectionHandle, pageId }) => {
   // get manually-curated data first
@@ -15,7 +16,7 @@ const MainGrid = ({ items = [], limit, listTypeId, sectionHandle, pageId }) => {
   const section = sectionMap[sectionHandle] || "pages";
   const tileType = sectionMap[sectionHandle] || "pages";
   const tabletNumber = sectionHandle === "staffGrid" ? 2 : 1;
-  const { data } = useList({
+  const { data, isLoading } = useList({
     limit,
     listTypeId,
     section,
@@ -32,7 +33,8 @@ const MainGrid = ({ items = [], limit, listTypeId, sectionHandle, pageId }) => {
 
   return (
     <>
-      {allItems?.length > 0 && (
+      {isLoading && <Loader speed="fast" isVisible />}
+      {!isLoading && allItems?.length > 0 && (
         <Grid columns={limit === 4 ? 4 : 3} tablet={tabletNumber}>
           {allItems.map(
             (

--- a/components/content-blocks/GridBlock/NewsGrid.js
+++ b/components/content-blocks/GridBlock/NewsGrid.js
@@ -8,6 +8,7 @@ import {
 } from "@/lib/utils";
 import { Grid } from "@rubin-epo/epo-react-lib";
 import Tile from "@/atomic/Tile";
+import Loader from "@/atomic/Loader";
 
 const NewsGrid = ({ items = [], limit, listTypeId, sectionHandle, pageId }) => {
   const { t } = useTranslation();
@@ -16,7 +17,7 @@ const NewsGrid = ({ items = [], limit, listTypeId, sectionHandle, pageId }) => {
   // get manually-curated data first
   let allItems = normalizeItemData(items);
 
-  const { data } = useList({
+  const { data, isLoading } = useList({
     limit,
     listTypeId,
     section: "news",
@@ -31,7 +32,8 @@ const NewsGrid = ({ items = [], limit, listTypeId, sectionHandle, pageId }) => {
 
   return (
     <>
-      {allItems?.length > 0 && (
+      {isLoading && <Loader speed="fast" isVisible />}
+      {!isLoading && allItems?.length > 0 && (
         <Grid columns={2} showFeature={true}>
           {allItems.map(
             (

--- a/components/dynamic/DataList/index.js
+++ b/components/dynamic/DataList/index.js
@@ -1,13 +1,16 @@
 import { useRouter } from "next/router";
 import PropTypes from "prop-types";
 import { useTranslation } from "react-i18next";
-import { Container } from "@rubin-epo/epo-react-lib";
+import { Container, Buttonish } from "@rubin-epo/epo-react-lib";
+import Loader from "@/atomic/Loader";
+import Pagination from "@/page/Pagination";
 import {
   usePathData,
   normalizePathData,
   useList,
   useGlobalData,
 } from "@/lib/utils";
+import * as Styled from "./styles";
 
 const DataList = ({
   children,
@@ -18,6 +21,10 @@ const DataList = ({
   showsFeatured = false,
   section = null,
   isRelatedList = false,
+  width = "regular",
+  header,
+  footerButton,
+  loaderDescription,
 }) => {
   const { t } = useTranslation();
   const { asPath, query } = usePathData();
@@ -49,29 +56,60 @@ const DataList = ({
     section,
   });
 
-  if (isLoading || isError) return null;
+  function renderData() {
+    const { offset, total } = data;
+    const numberOfPages = Math.ceil(total / limit) || 1;
 
-  const { offset, total } = data;
-  const numberOfPages = Math.ceil(total / limit) || 1;
+    // if our page is out of bounds, we must instead go to the last page with data
+    if (offset > total) {
+      router.push({
+        pathname,
+        query: { ...pathParams, page: numberOfPages },
+      });
+    }
 
-  // if our page is out of bounds, we must instead go to the last page with data
-  if (offset > total) {
-    router.push({
-      pathname,
-      query: { ...pathParams, page: numberOfPages },
-    });
+    if (total === 0 && isRelatedList) return null;
+    if (total === 0) return <div>{t(`search-no-results`)}</div>;
+    return children(data);
   }
 
-  if (total === 0 && isRelatedList) return null;
+  function renderPagination() {
+    const { offset, page, total } = data;
 
-  if (total === 0)
+    if (limit >= total || section === "glossaryTerms" || isRelatedList)
+      return null;
     return (
-      <Container>
-        <div>{t(`search-no-results`)}</div>
-      </Container>
+      <Pagination limit={limit} offset={offset} page={page} total={total} />
     );
+  }
 
-  return children(data);
+  if (isError) return null;
+
+  return (
+    <>
+      <Container width={width}>
+        {header && <Styled.Header>{header}</Styled.Header>}
+        {isLoading && (
+          <Loader
+            speed="fast"
+            isVisible
+            description={loaderDescription || t("loading")}
+          />
+        )}
+        {!isLoading && data && renderData()}
+        {footerButton && (
+          <Styled.Footer>
+            <Buttonish
+              isBlock={true}
+              text={footerButton.text}
+              url={`/${footerButton.uri}`}
+            />
+          </Styled.Footer>
+        )}
+      </Container>
+      {!isLoading && data && renderPagination()}
+    </>
+  );
 };
 
 DataList.propTypes = {
@@ -87,6 +125,10 @@ DataList.propTypes = {
   limit: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   section: PropTypes.string,
   isRelatedList: PropTypes.bool,
+  width: PropTypes.string,
+  header: PropTypes.string,
+  footerButton: PropTypes.object,
+  loaderDescription: PropTypes.string,
 };
 
 export default DataList;

--- a/components/dynamic/DataList/styles.js
+++ b/components/dynamic/DataList/styles.js
@@ -1,0 +1,12 @@
+import styled from "styled-components";
+import { fluidScale } from "@/styles/globalStyles";
+
+export const Header = styled.h2`
+  margin-bottom: ${fluidScale("40px", "20px")};
+  padding-bottom: 10px;
+  border-bottom: 10px solid var(--turquoise85);
+`;
+
+export const Footer = styled.div`
+  padding-top: 40px;
+`;

--- a/components/dynamic/EventList/index.js
+++ b/components/dynamic/EventList/index.js
@@ -1,14 +1,8 @@
 import PropTypes from "prop-types";
 import { useTranslation } from "react-i18next";
-import {
-  Container,
-  Grid,
-  Buttonish,
-  IconComposer,
-} from "@rubin-epo/epo-react-lib";
+import { Grid, IconComposer } from "@rubin-epo/epo-react-lib";
 import DataList from "@/dynamic/DataList";
 import Tile from "@/atomic/Tile";
-import Pagination from "@/page/Pagination";
 import {
   checkIfBetweenDates,
   createLocationString,
@@ -46,117 +40,97 @@ const EventList = ({
       excludeId={excludeId}
       limit={limit}
       section="events"
+      width={isWide ? "regular" : "narrow"}
+      header={header}
+      footerButton={button}
+      loaderDescription={t("events.loading")}
     >
-      {({ entries, offset, page, total }) => (
+      {({ entries }) => (
         <>
-          <Container width={isWide ? "regular" : "narrow"}>
-            <div>
-              {header && <Styled.Header>{header}</Styled.Header>}
-              {entries?.length > 0 && (
-                <Grid columns={1}>
-                  {entries.map(
-                    ({
-                      address,
-                      city,
-                      country,
-                      startDate,
-                      endDate,
-                      description,
-                      id,
-                      image,
-                      eventType,
-                      registrationCloseDate,
-                      registrationOpenDate,
-                      title,
-                      state,
-                      uri,
-                    }) => {
-                      // logic for displaying city/state in US, city/country outside
-                      const loc = createLocationString(city, state, country);
+          {entries?.length > 0 && (
+            <Grid columns={1}>
+              {entries.map(
+                ({
+                  address,
+                  city,
+                  country,
+                  startDate,
+                  endDate,
+                  description,
+                  id,
+                  image,
+                  eventType,
+                  registrationCloseDate,
+                  registrationOpenDate,
+                  title,
+                  state,
+                  uri,
+                }) => {
+                  // logic for displaying city/state in US, city/country outside
+                  const loc = createLocationString(city, state, country);
 
-                      // check registration
-                      const isThereRegistration = !!registrationCloseDate;
-                      const registration = checkIfBetweenDates(
-                        registrationOpenDate,
-                        registrationCloseDate
-                      )
-                        ? "open"
-                        : "closed";
+                  // check registration
+                  const isThereRegistration = !!registrationCloseDate;
+                  const registration = checkIfBetweenDates(
+                    registrationOpenDate,
+                    registrationCloseDate
+                  )
+                    ? "open"
+                    : "closed";
 
-                      const lock =
-                        registration === "open" ? "LockOpen" : "LockClosed";
+                  const lock =
+                    registration === "open" ? "LockOpen" : "LockClosed";
 
-                      const endDateObject = makeDateObject(endDate, lang, true);
+                  const endDateObject = makeDateObject(endDate, lang, true);
 
-                      const startDateObject = startDate
-                        ? makeDateObject(startDate, lang, true)
-                        : null;
+                  const startDateObject = startDate
+                    ? makeDateObject(startDate, lang, true)
+                    : null;
 
-                      return (
-                        /* eslint-disable */
-                        <Tile
-                          className={isThereRegistration ? registration : null}
-                          key={id}
-                          footer={
-                            isThereRegistration
-                              ? {
-                                  sticker: (
-                                    <Styled.Sticker>
-                                      <IconComposer icon={lock} size={18} />
-                                      <span>{t(`events.${registration}`)}</span>
-                                    </Styled.Sticker>
-                                  ),
-                                }
-                              : null
-                          }
-                          image={image?.[0]}
-                          link={uri}
-                          pretitle={
-                            gridType === "events" && eventType?.[0]?.title
-                              ? eventType?.[0]?.title
-                              : " "
-                          }
-                          subtitle={
-                            <Styled.DateWrapper
-                              $hasStartDate={!!startDateObject}
-                            >
-                              {startDateObject && (
-                                <>
-                                  {renderDate(startDateObject)}
-                                  <Styled.DateEmDash>—</Styled.DateEmDash>
-                                </>
-                              )}
-                              {renderDate(endDateObject)}
-                            </Styled.DateWrapper>
-                          }
-                          text={description}
-                          title={`${title}${loc && " — " + loc}`}
-                          titleTag={"h2"}
-                          type={gridType}
-                        />
-                      );
-                    }
-                  )}
-                </Grid>
+                  return (
+                    /* eslint-disable */
+                    <Tile
+                      className={isThereRegistration ? registration : null}
+                      key={id}
+                      footer={
+                        isThereRegistration
+                          ? {
+                              sticker: (
+                                <Styled.Sticker>
+                                  <IconComposer icon={lock} size={18} />
+                                  <span>{t(`events.${registration}`)}</span>
+                                </Styled.Sticker>
+                              ),
+                            }
+                          : null
+                      }
+                      image={image?.[0]}
+                      link={uri}
+                      pretitle={
+                        gridType === "events" && eventType?.[0]?.title
+                          ? eventType?.[0]?.title
+                          : " "
+                      }
+                      subtitle={
+                        <Styled.DateWrapper $hasStartDate={!!startDateObject}>
+                          {startDateObject && (
+                            <>
+                              {renderDate(startDateObject)}
+                              <Styled.DateEmDash>—</Styled.DateEmDash>
+                            </>
+                          )}
+                          {renderDate(endDateObject)}
+                        </Styled.DateWrapper>
+                      }
+                      text={description}
+                      title={`${title}${loc && " — " + loc}`}
+                      titleTag={"h2"}
+                      type={gridType}
+                    />
+                  );
+                }
               )}
-              {button && (
-                <Styled.Footer>
-                  <Buttonish
-                    isBlock={true}
-                    text={button.text}
-                    url={`/${button.uri}`}
-                  />
-                </Styled.Footer>
-              )}
-            </div>
-          </Container>
-          {limit >= 8 && (
-            <Pagination
-              limit={limit}
-              offset={offset}
-              page={page}
-              total={total}
-            />
+            </Grid>
           )}
         </>
       )}

--- a/components/dynamic/EventList/styles.js
+++ b/components/dynamic/EventList/styles.js
@@ -1,16 +1,6 @@
 import styled, { css } from "styled-components";
 import { BREAK_MOBILE_MIN, fluidScale, respond } from "@/styles/globalStyles";
 
-export const Header = styled.h2`
-  margin-bottom: ${fluidScale("40px", "20px")};
-  padding-bottom: 10px;
-  border-bottom: 10px solid var(--turquoise85);
-`;
-
-export const Footer = styled.div`
-  padding-top: 40px;
-`;
-
 export const DateWrapper = styled.div`
   display: flex;
   justify-content: center;

--- a/components/dynamic/GalleryList/index.js
+++ b/components/dynamic/GalleryList/index.js
@@ -1,9 +1,11 @@
 import PropTypes from "prop-types";
-import Pagination from "@/page/Pagination";
+import { useTranslation } from "react-i18next";
 import DataList from "@/dynamic/DataList";
 import { MasonryGrid } from "@rubin-epo/epo-react-lib";
 
 const GalleryList = ({ excludeId = null, limit = 20, component }) => {
+  const { t } = useTranslation();
+
   return (
     <div className="l-pad-top-large">
       <DataList
@@ -11,18 +13,12 @@ const GalleryList = ({ excludeId = null, limit = 20, component }) => {
         limit={limit}
         section="galleryItems"
         component={component}
+        width="regular"
+        loaderDescription={t("gallery.loading")}
       >
-        {({ entries, offset, page, total }) => (
+        {({ entries }) => (
           <>
             {entries?.length > 0 && <MasonryGrid items={entries}></MasonryGrid>}
-            {limit >= 20 && (
-              <Pagination
-                limit={limit}
-                offset={offset}
-                page={page}
-                total={total}
-              />
-            )}
           </>
         )}
       </DataList>
@@ -34,9 +30,6 @@ GalleryList.propTypes = {
   excludeId: PropTypes.string,
   limit: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   component: PropTypes.node,
-  header: PropTypes.string,
-  button: PropTypes.object,
-  isWide: PropTypes.bool,
 };
 
 export default GalleryList;

--- a/components/dynamic/GlossaryList/index.js
+++ b/components/dynamic/GlossaryList/index.js
@@ -1,12 +1,14 @@
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import groupBy from "lodash/groupBy";
 import sortBy from "lodash/sortBy";
 import DataList from "@/dynamic/DataList";
-import { Columns, Container, MixedLink } from "@rubin-epo/epo-react-lib";
+import { Columns, MixedLink } from "@rubin-epo/epo-react-lib";
 import * as Styled from "./styles";
 
 // eslint-disable-next-line react/prop-types
 export default function GlossaryList({ excludeId = null, limit = null }) {
+  const { t } = useTranslation();
   const alpha = Array.from(Array(26)).map((e, i) => i + 65);
   const alphabet = alpha.map((x) => String.fromCharCode(x));
   const [filterChar, setFilteredChar] = useState(null);
@@ -28,66 +30,70 @@ export default function GlossaryList({ excludeId = null, limit = null }) {
   };
 
   return (
-    <Container width="wide">
-      <DataList excludeId={excludeId} limit={limit} section="glossaryTerms">
-        {({ entries }) => {
-          const groupedEntries = getGroupedEntires(entries);
-          const charKeys = Object.keys(groupedEntries);
+    <DataList
+      excludeId={excludeId}
+      limit={limit}
+      section="glossaryTerms"
+      width="wide"
+      loaderDescription={t("glossary.loading")}
+    >
+      {({ entries }) => {
+        const groupedEntries = getGroupedEntires(entries);
+        const charKeys = Object.keys(groupedEntries);
 
-          return (
-            <>
-              <nav>
-                <Styled.AlphaList>
-                  {alphabet.map((char) => (
-                    <Styled.AlphaItem key={char}>
-                      <Styled.AlphaButton
-                        disabled={!charKeys.includes(char)}
-                        aria-pressed={
-                          charKeys.includes(char)
-                            ? char === filterChar
-                            : undefined
-                        }
-                        aria-controls={
-                          charKeys.includes(char) ? "termColumns" : undefined
-                        }
-                        type="button"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          handleClick(char);
-                        }}
-                      >
-                        {char}
-                      </Styled.AlphaButton>
-                    </Styled.AlphaItem>
-                  ))}
-                </Styled.AlphaList>
-              </nav>
-              <Columns id="termColumns" width={300} gap={25}>
-                {charKeys
-                  .filter((char) => !filterChar || filterChar === char)
-                  .map((char) => (
-                    <Styled.TermGroup key={char}>
-                      <Styled.TermGroupHeader>{char}</Styled.TermGroupHeader>
-                      <Styled.TermList>
-                        {groupedEntries[char].map(({ id, title, uri }) => (
-                          <li key={id}>
-                            <Styled.TermLink
-                              className="glossaryTerms"
-                              as={MixedLink}
-                              url={uri}
-                            >
-                              {title}
-                            </Styled.TermLink>
-                          </li>
-                        ))}
-                      </Styled.TermList>
-                    </Styled.TermGroup>
-                  ))}
-              </Columns>
-            </>
-          );
-        }}
-      </DataList>
-    </Container>
+        return (
+          <>
+            <nav>
+              <Styled.AlphaList>
+                {alphabet.map((char) => (
+                  <Styled.AlphaItem key={char}>
+                    <Styled.AlphaButton
+                      disabled={!charKeys.includes(char)}
+                      aria-pressed={
+                        charKeys.includes(char)
+                          ? char === filterChar
+                          : undefined
+                      }
+                      aria-controls={
+                        charKeys.includes(char) ? "termColumns" : undefined
+                      }
+                      type="button"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        handleClick(char);
+                      }}
+                    >
+                      {char}
+                    </Styled.AlphaButton>
+                  </Styled.AlphaItem>
+                ))}
+              </Styled.AlphaList>
+            </nav>
+            <Columns id="termColumns" width={300} gap={25}>
+              {charKeys
+                .filter((char) => !filterChar || filterChar === char)
+                .map((char) => (
+                  <Styled.TermGroup key={char}>
+                    <Styled.TermGroupHeader>{char}</Styled.TermGroupHeader>
+                    <Styled.TermList>
+                      {groupedEntries[char].map(({ id, title, uri }) => (
+                        <li key={id}>
+                          <Styled.TermLink
+                            className="glossaryTerms"
+                            as={MixedLink}
+                            url={uri}
+                          >
+                            {title}
+                          </Styled.TermLink>
+                        </li>
+                      ))}
+                    </Styled.TermList>
+                  </Styled.TermGroup>
+                ))}
+            </Columns>
+          </>
+        );
+      }}
+    </DataList>
   );
 }

--- a/components/dynamic/JobList/index.js
+++ b/components/dynamic/JobList/index.js
@@ -1,17 +1,10 @@
 import PropTypes from "prop-types";
-import styled from "styled-components";
 import { useTranslation } from "react-i18next";
-import {
-  Container,
-  Grid,
-  Buttonish,
-  IconComposer,
-} from "@rubin-epo/epo-react-lib";
+import { Grid, IconComposer } from "@rubin-epo/epo-react-lib";
 import DataList from "@/dynamic/DataList";
 import Tile from "@/atomic/Tile";
-import Pagination from "@/page/Pagination";
 import { checkIfBetweenDates, createLocationString } from "@/lib/utils";
-import { fluidScale } from "@/styles/globalStyles";
+import * as Styled from "./styles";
 
 const JobList = ({
   button,
@@ -25,127 +18,85 @@ const JobList = ({
   const cols = limit === 20 ? 2 : 4;
 
   return (
-    <DataList excludeId={excludeId} limit={limit} section="jobs">
-      {({ entries, offset, page, total }) => (
+    <DataList
+      excludeId={excludeId}
+      limit={limit}
+      section="jobs"
+      header={header}
+      width={isWide ? "regular" : "narrow"}
+      footerButton={button}
+      loaderDescription={t("jobs.loading")}
+    >
+      {({ entries }) => (
         <>
-          <Container width={isWide ? "regular" : "narrow"}>
-            <div>
-              {header && <Header>{header}</Header>}
-              {entries?.length > 0 && (
-                <Grid columns={cols}>
-                  {entries.map(
-                    (
-                      {
-                        closeDate,
-                        id,
-                        subLocation,
-                        jobPosition,
-                        openDate,
-                        title,
-                        externalUrl,
-                      },
-                      i
-                    ) => {
-                      // logic for displaying city/state in US, city/country outside
-                      const Location = (
-                        <LocationWrapper>
-                          <IconComposer icon="Pin" />
-                          <span>
-                            {`${
-                              subLocation?.[0].title
-                            } | ${createLocationString(
-                              subLocation?.[0].city,
-                              subLocation?.[0].state,
-                              subLocation?.[0].country
-                            )}`}
-                          </span>
-                        </LocationWrapper>
-                      );
+          {entries?.length > 0 && (
+            <Grid columns={cols}>
+              {entries.map(
+                (
+                  {
+                    closeDate,
+                    id,
+                    subLocation,
+                    jobPosition,
+                    openDate,
+                    title,
+                    externalUrl,
+                  },
+                  i
+                ) => {
+                  // logic for displaying city/state in US, city/country outside
+                  const Location = (
+                    <Styled.LocationWrapper>
+                      <IconComposer icon="Pin" />
+                      <span>
+                        {`${subLocation?.[0].title} | ${createLocationString(
+                          subLocation?.[0].city,
+                          subLocation?.[0].state,
+                          subLocation?.[0].country
+                        )}`}
+                      </span>
+                    </Styled.LocationWrapper>
+                  );
 
-                      // logic for open/closed
-                      const checkOpen = checkIfBetweenDates(openDate, closeDate)
-                        ? "open"
-                        : "closed";
-                      const lock =
-                        checkOpen === "open" ? "LockOpen" : "LockClosed";
+                  // logic for open/closed
+                  const checkOpen = checkIfBetweenDates(openDate, closeDate)
+                    ? "open"
+                    : "closed";
+                  const lock = checkOpen === "open" ? "LockOpen" : "LockClosed";
 
-                      return (
-                        <Tile
-                          className={checkOpen === "closed" ? "closed" : null}
-                          key={id}
-                          footer={
-                            checkOpen && {
-                              sticker: (
-                                <Sticker>
-                                  <IconComposer icon={lock} />
-                                  <span>{t(`jobs.${checkOpen}`)}</span>
-                                </Sticker>
-                              ),
-                            }
-                          }
-                          link={externalUrl}
-                          pretitle={
-                            jobPosition?.[0]?.title ? jobPosition[0].title : " "
-                          }
-                          subtitle={Location}
-                          title={title}
-                          titleTag={"h2"}
-                          type={gridType}
-                        />
-                      );
-                    }
-                  )}
-                </Grid>
+                  return (
+                    <Tile
+                      className={checkOpen === "closed" ? "closed" : null}
+                      key={id}
+                      footer={
+                        checkOpen && {
+                          sticker: (
+                            <Styled.Sticker>
+                              <IconComposer icon={lock} />
+                              <span>{t(`jobs.${checkOpen}`)}</span>
+                            </Styled.Sticker>
+                          ),
+                        }
+                      }
+                      link={externalUrl}
+                      pretitle={
+                        jobPosition?.[0]?.title ? jobPosition[0].title : " "
+                      }
+                      subtitle={Location}
+                      title={title}
+                      titleTag={"h2"}
+                      type={gridType}
+                    />
+                  );
+                }
               )}
-              {button && (
-                <Footer>
-                  <Buttonish
-                    isBlock={true}
-                    text={button.text}
-                    url={`/${button.uri}`}
-                  />
-                </Footer>
-              )}
-            </div>
-          </Container>
-          {limit >= 10 && (
-            <Pagination
-              limit={limit}
-              offset={offset}
-              page={page}
-              total={total}
-            />
+            </Grid>
           )}
         </>
       )}
     </DataList>
   );
 };
-
-const Header = styled.h2`
-  margin-bottom: ${fluidScale("40px", "20px")};
-  padding-bottom: 10px;
-  border-bottom: 10px solid var(--turquoise85);
-`;
-
-const Footer = styled.div`
-  padding-top: 40px;
-`;
-
-const Sticker = styled.div`
-  display: flex;
-  align-items: center;
-  padding: 0.25em;
-
-  > * + * {
-    margin-left: 5px;
-  }
-`;
-
-const LocationWrapper = styled.div`
-  display: flex;
-  align-items: baseline;
-`;
 
 JobList.propTypes = {
   excludeId: PropTypes.string,

--- a/components/dynamic/JobList/styles.js
+++ b/components/dynamic/JobList/styles.js
@@ -1,0 +1,16 @@
+import styled from "styled-components";
+
+export const Sticker = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 0.25em;
+
+  > * + * {
+    margin-left: 5px;
+  }
+`;
+
+export const LocationWrapper = styled.div`
+  display: flex;
+  align-items: baseline;
+`;

--- a/components/dynamic/NewsList/index.js
+++ b/components/dynamic/NewsList/index.js
@@ -1,16 +1,13 @@
 import PropTypes from "prop-types";
-import styled from "styled-components";
 import { useTranslation } from "react-i18next";
-import { Container, Grid, Buttonish } from "@rubin-epo/epo-react-lib";
+import { Grid } from "@rubin-epo/epo-react-lib";
 import DataList from "@/dynamic/DataList";
 import Tile from "@/atomic/Tile";
-import Pagination from "@/page/Pagination";
 import {
   makeDateString,
   makeTruncatedString,
   useGlobalData,
 } from "@/lib/utils";
-import { fluidScale } from "@/styles/globalStyles";
 
 const NewsList = ({
   button,
@@ -20,6 +17,7 @@ const NewsList = ({
   limit: initialLimit = 10,
   isWide = false,
   gridType = "news",
+  isRelatedList = false,
 }) => {
   const { t } = useTranslation();
   const localeInfo = useGlobalData("localeInfo");
@@ -34,94 +32,64 @@ const NewsList = ({
       limit={initialLimit}
       showsFeatured={canShowFeatured}
       section="news"
+      header={header}
+      width={isWide ? "regular" : "narrow"}
+      footerButton={button}
+      isRelatedList={isRelatedList}
+      loaderDescription={t("news.loading")}
     >
-      {({ entries, limit, offset, page, total }) => (
+      {({ entries, page }) => (
         <>
-          <Container width={isWide ? "regular" : "narrow"}>
-            <div>
-              {header && <Header>{header}</Header>}
-              {entries?.length > 0 && (
-                <Grid
-                  showFeature={canShowFeatured && page === 1}
-                  columns={cols}
-                >
-                  {entries.map(
-                    (
-                      {
-                        date,
-                        description,
-                        id,
-                        image,
-                        newsAssets,
-                        postType,
-                        title,
-                        uri,
-                        url,
-                      },
-                      i
-                    ) => (
-                      <Tile
-                        key={id}
-                        footer={
-                          gridType === "news"
-                            ? {
-                                button: t("read-more"),
-                              }
-                            : null
-                        }
-                        image={image?.[0]}
-                        isFeature={canShowFeatured && page === 1 && i === 0}
-                        link={uri}
-                        pretitle={
-                          gridType === "news" && postType?.[0]?.title
-                            ? postType[0].title
-                            : null
-                        }
-                        subtitle={makeDateString(date, lang)}
-                        text={makeTruncatedString(description, 30)}
-                        title={title}
-                        titleTag={"h2"}
-                        type={gridType}
-                        showSharePopup
-                      />
-                    )
-                  )}
-                </Grid>
-              )}
-              {button && (
-                <Footer>
-                  <Buttonish
-                    isBlock={true}
-                    text={button.text}
-                    url={`/${button.uri}`}
+          {entries?.length > 0 && (
+            <Grid showFeature={canShowFeatured && page === 1} columns={cols}>
+              {entries.map(
+                (
+                  {
+                    date,
+                    description,
+                    id,
+                    image,
+                    newsAssets,
+                    postType,
+                    title,
+                    uri,
+                    url,
+                  },
+                  i
+                ) => (
+                  <Tile
+                    key={id}
+                    footer={
+                      gridType === "news"
+                        ? {
+                            button: t("read-more"),
+                          }
+                        : null
+                    }
+                    image={image?.[0]}
+                    isFeature={canShowFeatured && page === 1 && i === 0}
+                    link={uri}
+                    pretitle={
+                      gridType === "news" && postType?.[0]?.title
+                        ? postType[0].title
+                        : null
+                    }
+                    subtitle={makeDateString(date, lang)}
+                    text={makeTruncatedString(description, 30)}
+                    title={title}
+                    titleTag={"h2"}
+                    type={gridType}
+                    showSharePopup
                   />
-                </Footer>
+                )
               )}
-            </div>
-          </Container>
-          {initialLimit >= 10 && (
-            <Pagination
-              limit={limit}
-              offset={offset}
-              page={page}
-              total={total}
-            />
+            </Grid>
           )}
         </>
       )}
     </DataList>
   );
 };
-
-const Header = styled.h2`
-  margin-bottom: ${fluidScale("40px", "20px")};
-  padding-bottom: 10px;
-  border-bottom: 10px solid var(--turquoise85);
-`;
-
-const Footer = styled.div`
-  padding-top: 40px;
-`;
 
 NewsList.propTypes = {
   component: PropTypes.string,
@@ -131,6 +99,7 @@ NewsList.propTypes = {
   button: PropTypes.object,
   isWide: PropTypes.bool,
   gridType: PropTypes.string,
+  isRelatedList: PropTypes.bool,
 };
 
 export default NewsList;

--- a/components/dynamic/RelatedList/index.js
+++ b/components/dynamic/RelatedList/index.js
@@ -1,12 +1,9 @@
 import PropTypes from "prop-types";
-import styled from "styled-components";
 import { useTranslation } from "react-i18next";
 import striptags from "striptags";
-import { Container, Grid, Buttonish } from "@rubin-epo/epo-react-lib";
+import { Grid } from "@rubin-epo/epo-react-lib";
 import DataList from "@/dynamic/DataList";
 import Tile from "@/atomic/Tile";
-import Pagination from "@/page/Pagination";
-import { fluidScale } from "@/styles/globalStyles";
 
 const RelatedList = ({
   button,
@@ -20,61 +17,37 @@ const RelatedList = ({
   const cols = limit === 4 ? 4 : 3;
 
   return (
-    <DataList excludeId={excludeId} limit={limit} section="pages">
-      {({ entries, offset, page, total }) => (
+    <DataList
+      excludeId={excludeId}
+      limit={limit}
+      section="pages"
+      header={header}
+      width={isWide ? "regular" : "narrow"}
+      footerButton={button}
+      loaderDescription={t("related-content-loading")}
+    >
+      {({ entries }) => (
         <>
-          <Container width={isWide ? "regular" : "narrow"}>
-            <div>
-              {<Header>{header || t(`related-content`)}</Header>}
-              {entries?.length > 0 && (
-                <Grid columns={cols}>
-                  {entries.map(({ id, description, image, title, uri }, i) => (
-                    <Tile
-                      key={id}
-                      image={image?.[0]}
-                      link={uri}
-                      text={striptags(description)}
-                      title={title}
-                      titleTag={"h2"}
-                      type={gridType}
-                    />
-                  ))}
-                </Grid>
-              )}
-              {button && (
-                <Footer>
-                  <Buttonish
-                    isBlock={true}
-                    text={button.text}
-                    url={`/${button.uri}`}
-                  />
-                </Footer>
-              )}
-            </div>
-          </Container>
-          {limit >= 10 && (
-            <Pagination
-              limit={limit}
-              offset={offset}
-              page={page}
-              total={total}
-            />
+          {entries?.length > 0 && (
+            <Grid columns={cols}>
+              {entries.map(({ id, description, image, title, uri }, i) => (
+                <Tile
+                  key={id}
+                  image={image?.[0]}
+                  link={uri}
+                  text={striptags(description)}
+                  title={title}
+                  titleTag={"h2"}
+                  type={gridType}
+                />
+              ))}
+            </Grid>
           )}
         </>
       )}
     </DataList>
   );
 };
-
-const Header = styled.h2`
-  margin-bottom: ${fluidScale("40px", "20px")};
-  padding-bottom: 10px;
-  border-bottom: 10px solid var(--turquoise85);
-`;
-
-const Footer = styled.div`
-  padding-top: 40px;
-`;
 
 RelatedList.propTypes = {
   excludeId: PropTypes.string,

--- a/components/dynamic/SearchList/index.js
+++ b/components/dynamic/SearchList/index.js
@@ -1,6 +1,5 @@
 import PropTypes from "prop-types";
 import striptags from "striptags";
-import styled from "styled-components";
 import { useTranslation } from "react-i18next";
 import {
   makeBreadcrumbs,
@@ -9,12 +8,10 @@ import {
   makeTruncatedString,
   useGlobalData,
 } from "@/lib/utils";
-import { fluidScale } from "@/styles/globalStyles";
 import Breadcrumbs from "@/components/page/Breadcrumbs";
-import { Container, Grid, Buttonish } from "@rubin-epo/epo-react-lib";
+import { Grid } from "@rubin-epo/epo-react-lib";
 import DataList from "@/dynamic/DataList";
 import Tile from "@/atomic/Tile";
-import Pagination from "@/page/Pagination";
 
 const SearchList = ({
   button,
@@ -88,76 +85,47 @@ const SearchList = ({
   };
 
   return (
-    <DataList excludeId={excludeId} limit={limit} isSitewideSearch={true}>
-      {({ entries, offset, page, total }) => (
+    <DataList
+      excludeId={excludeId}
+      limit={limit}
+      isSitewideSearch={true}
+      header={header}
+      width={isWide ? "regular" : "narrow"}
+      footerButton={button}
+    >
+      {({ entries }) => (
         <>
-          <Container width={isWide ? "regular" : "narrow"}>
-            <div>
-              {header && <Header>{header}</Header>}
-              {entries?.length > 0 && (
-                <Grid columns={1}>
-                  {entries.map((entry) => {
-                    return entry.id ? (
-                      <Tile
-                        key={entry.id}
-                        image={entry.image?.[0]}
-                        link={entry.uri}
-                        pretitle={makePretitle(entry)}
-                        subtitle={
-                          entry.date &&
-                          `${t("published")} ${makeDateString(
-                            entry.date,
-                            lang
-                          )}`
-                        }
-                        text={
-                          entry.jobPosition
-                            ? t(`jobs.read-more`)
-                            : makeTruncatedString(striptags(entry.description))
-                        }
-                        title={entry.title}
-                        titleTag={"h2"}
-                        type="search"
-                      />
-                    ) : null;
-                  })}
-                </Grid>
-              )}
-
-              {button && (
-                <Footer>
-                  <Buttonish
-                    isBlock={true}
-                    text={button.text}
-                    url={`/${button.uri}`}
+          {entries?.length > 0 && (
+            <Grid columns={1}>
+              {entries.map((entry) => {
+                return entry.id ? (
+                  <Tile
+                    key={entry.id}
+                    image={entry.image?.[0]}
+                    link={entry.uri}
+                    pretitle={makePretitle(entry)}
+                    subtitle={
+                      entry.date &&
+                      `${t("published")} ${makeDateString(entry.date, lang)}`
+                    }
+                    text={
+                      entry.jobPosition
+                        ? t(`jobs.read-more`)
+                        : makeTruncatedString(striptags(entry.description))
+                    }
+                    title={entry.title}
+                    titleTag={"h2"}
+                    type="search"
                   />
-                </Footer>
-              )}
-            </div>
-          </Container>
-          {limit >= 10 && (
-            <Pagination
-              limit={limit}
-              offset={offset}
-              page={page}
-              total={total}
-            />
+                ) : null;
+              })}
+            </Grid>
           )}
         </>
       )}
     </DataList>
   );
 };
-
-const Header = styled.h2`
-  margin-bottom: ${fluidScale("40px", "20px")};
-  padding-bottom: 10px;
-  border-bottom: 10px solid var(--turquoise85);
-`;
-
-const Footer = styled.div`
-  padding-top: 40px;
-`;
 
 SearchList.propTypes = {
   excludeId: PropTypes.string,

--- a/components/dynamic/SlideshowList/index.js
+++ b/components/dynamic/SlideshowList/index.js
@@ -1,12 +1,9 @@
 import PropTypes from "prop-types";
-import styled from "styled-components";
 import striptags from "striptags";
 import { useTranslation } from "react-i18next";
-import { Container, Grid, Buttonish } from "@rubin-epo/epo-react-lib";
+import { Grid } from "@rubin-epo/epo-react-lib";
 import DataList from "@/dynamic/DataList";
 import Tile from "@/atomic/Tile";
-import Pagination from "@/page/Pagination";
-import { fluidScale } from "@/styles/globalStyles";
 
 const SlideshowList = ({
   button,
@@ -19,72 +16,48 @@ const SlideshowList = ({
   const { t } = useTranslation();
 
   return (
-    <DataList excludeId={excludeId} limit={limit} section="slideshows">
-      {({ entries, offset, page, total }) => (
+    <DataList
+      excludeId={excludeId}
+      limit={limit}
+      section="slideshows"
+      header={header}
+      width={isWide ? "regular" : "narrow"}
+      footerButton={button}
+      loaderDescription={t("gallery.loading-slideshows")}
+    >
+      {({ entries }) => (
         <>
-          <Container width={isWide ? "regular" : "narrow"}>
-            <div>
-              {header && <Header>{header}</Header>}
-              {entries?.length > 0 && (
-                <Grid columns={1}>
-                  {entries.map(({ id, description, image, title, uri }, i) => (
-                    <Tile
-                      key={id}
-                      footer={
-                        gridType === "darkSlide" || gridType === "slideshows"
-                          ? { button: t(`gallery.start-slideshow`) }
-                          : null
-                      }
-                      image={image?.[0]}
-                      isFeature={true}
-                      link={uri}
-                      pretitle={
-                        gridType === "darkSlide" || gridType === "slideshows"
-                          ? t(`gallery.slideshow`)
-                          : null
-                      }
-                      text={striptags(description)}
-                      title={title}
-                      titleTag={"h2"}
-                      type={gridType}
-                    />
-                  ))}
-                </Grid>
-              )}
-              {button && (
-                <Footer>
-                  <Buttonish
-                    isBlock={true}
-                    text={button.text}
-                    url={`/${button.uri}`}
-                  />
-                </Footer>
-              )}
-            </div>
-          </Container>
-          {limit >= 10 && (
-            <Pagination
-              limit={limit}
-              offset={offset}
-              page={page}
-              total={total}
-            />
+          {entries?.length > 0 && (
+            <Grid columns={1}>
+              {entries.map(({ id, description, image, title, uri }, i) => (
+                <Tile
+                  key={id}
+                  footer={
+                    gridType === "darkSlide" || gridType === "slideshows"
+                      ? { button: t(`gallery.start-slideshow`) }
+                      : null
+                  }
+                  image={image?.[0]}
+                  isFeature={true}
+                  link={uri}
+                  pretitle={
+                    gridType === "darkSlide" || gridType === "slideshows"
+                      ? t(`gallery.slideshow`)
+                      : null
+                  }
+                  text={striptags(description)}
+                  title={title}
+                  titleTag={"h2"}
+                  type={gridType}
+                />
+              ))}
+            </Grid>
           )}
         </>
       )}
     </DataList>
   );
 };
-
-const Header = styled.h2`
-  margin-bottom: ${fluidScale("40px", "20px")};
-  padding-bottom: 10px;
-  border-bottom: 10px solid var(--turquoise85);
-`;
-
-const Footer = styled.div`
-  padding-top: 40px;
-`;
 
 SlideshowList.propTypes = {
   excludeId: PropTypes.string,

--- a/components/dynamic/StaffList/index.js
+++ b/components/dynamic/StaffList/index.js
@@ -1,10 +1,8 @@
 import PropTypes from "prop-types";
-import styled from "styled-components";
-import { Container, Grid, Buttonish } from "@rubin-epo/epo-react-lib";
+import { useTranslation } from "react-i18next";
+import { Grid } from "@rubin-epo/epo-react-lib";
 import DataList from "@/dynamic/DataList";
 import Tile from "@/atomic/Tile";
-import Pagination from "@/page/Pagination";
-import { fluidScale } from "@/styles/globalStyles";
 
 const StaffList = ({
   component,
@@ -13,7 +11,9 @@ const StaffList = ({
   limit = 15,
   button,
   isWide = false,
+  isRelatedList = false,
 }) => {
+  const { t } = useTranslation();
   const cols = limit === 4 ? 4 : 3;
 
   return (
@@ -22,61 +22,34 @@ const StaffList = ({
       excludeId={excludeId}
       limit={limit}
       section="staffProfiles"
+      header={header}
+      width={isWide ? "regular" : "narrow"}
+      footerButton={button}
+      isRelatedList={isRelatedList}
+      loaderDescription={t("staff.loading")}
     >
-      {({ entries, offset, page, total }) => (
+      {({ entries }) => (
         <>
-          <Container width={isWide ? "regular" : "narrow"}>
-            <div>
-              {header && <Header>{header}</Header>}
-              {entries?.length > 0 && (
-                <Grid columns={cols}>
-                  {entries.map(({ id, plainText, image, title, uri }) => (
-                    <Tile
-                      key={id}
-                      title={title}
-                      titleTag={"h2"}
-                      text={plainText}
-                      image={image?.[0]}
-                      link={uri}
-                      type={"staffProfiles"}
-                    />
-                  ))}
-                </Grid>
-              )}
-              {button && (
-                <Footer>
-                  <Buttonish
-                    isBlock={true}
-                    text={button.text}
-                    url={`/${button.uri}`}
-                  />
-                </Footer>
-              )}
-            </div>
-          </Container>
-          {limit >= 15 && (
-            <Pagination
-              limit={limit}
-              offset={offset}
-              page={page}
-              total={total}
-            />
+          {entries?.length > 0 && (
+            <Grid columns={cols}>
+              {entries.map(({ id, plainText, image, title, uri }) => (
+                <Tile
+                  key={id}
+                  title={title}
+                  titleTag={"h2"}
+                  text={plainText}
+                  image={image?.[0]}
+                  link={uri}
+                  type={"staffProfiles"}
+                />
+              ))}
+            </Grid>
           )}
         </>
       )}
     </DataList>
   );
 };
-
-const Header = styled.h2`
-  margin-bottom: ${fluidScale("40px", "20px")};
-  padding-bottom: 10px;
-  border-bottom: 10px solid var(--turquoise85);
-`;
-
-const Footer = styled.div`
-  padding-top: 40px;
-`;
 
 StaffList.propTypes = {
   component: PropTypes.string,
@@ -85,6 +58,7 @@ StaffList.propTypes = {
   header: PropTypes.string,
   button: PropTypes.object,
   isWide: PropTypes.bool,
+  isRelatedList: PropTypes.bool,
 };
 
 export default StaffList;

--- a/components/templates/NewsPage/index.js
+++ b/components/templates/NewsPage/index.js
@@ -199,8 +199,9 @@ export default function NewsPage({
         excludeId={id}
         header={t(`news.related-posts`)}
         limit={3}
-        isWide={true}
+        isWide
         gridType="pages"
+        isRelatedList
       />
     </Body>
   );

--- a/components/templates/StaffPage/index.js
+++ b/components/templates/StaffPage/index.js
@@ -116,7 +116,8 @@ export default function StaffPage({
               text: t(`staff.back-to-profiles`),
               uri: parentEntry?.uri || parentUri,
             }}
-            isWide={true}
+            isWide
+            isRelatedList
           />
         }
       >

--- a/lib/localeStrings/en.json
+++ b/lib/localeStrings/en.json
@@ -7,9 +7,11 @@
     "breaking-news": "Breaking News",
     "cell": "Cell",
     "localize-content": "Localize site content",
+    "loading": "Loading…",
     "media": "Media",
     "read-more": "Read more",
     "related-content": "Related content",
+    "related-content-loading": "Loading related content",
     "error-title": "Error",
     "error-text": "There has been an error.",
     "page-not-found-title": "Page not found",
@@ -82,7 +84,8 @@
       "related-events": "Other Events",
       "go-to-events": "Go to events",
       "upcoming": "Upcoming events",
-      "past": "Past events"
+      "past": "Past events",
+      "loading": "Loading the Calendar..."
     },
     "gallery": {
       "about-the-image": "About the Image",
@@ -92,6 +95,7 @@
       "additional-information": "Additional information",
       "available-sizes": "Available Sizes",
       "curated-slideshows": "Curated Slideshows",
+      "loading-slideshows": "Loading the Slideshows...",
       "download-image": "Download image",
       "download-video": "Download video",
       "download-3d": "Download 3d model",
@@ -123,17 +127,20 @@
       "1080p": "1080p",
       "720p": "720p",
       "480p": "480p",
-      "320p": "320p"
+      "320p": "320p",
+      "loading": "Loading the Gallery..."
     },
     "jobs": {
       "jobs": "Jobs",
       "read-more": "Read more about this position.",
       "open": "Open",
-      "closed": "Closed"
+      "closed": "Closed",
+      "loading": "Loading the Jobs..."
     },
     "news": {
       "related-posts": "Related News Posts",
-      "back-to-posts": "Go Back to News Posts"
+      "back-to-posts": "Go Back to News Posts",
+      "loading": "Loading the News..."
     },
     "pagination": {
       "label": "Pagination",
@@ -157,7 +164,8 @@
       "non-scientific-staff": "Non-scientific Staff Profile",
       "browse-more": "Browse More Profiles",
       "back-to-profiles": "Go Back to Profiles",
-      "trading-card": "Trading card"
+      "trading-card": "Trading card",
+      "loading": "Loading the Rubin Voices..."
     },
     "telescope": {
       "state": "State",
@@ -286,7 +294,8 @@
       "delete_error_header": "Error!"
     },
     "glossary": {
-      "back_button": "Go back to Glossary"
+      "back_button": "Go back to Glossary",
+      "loading": "Loading the Glossary..."
     },
     "restricted": {
       "header_approval_pending": "Content not yet available",

--- a/lib/localeStrings/es.json
+++ b/lib/localeStrings/es.json
@@ -7,9 +7,11 @@
     "breaking-news": "Últimas noticias",
     "cell": "Celda",
     "localize-content": "Localizar el contenido del sitio",
+    "loading": "Cargando…",
     "media": "Multimedia",
     "read-more": "Leer más",
     "related-content": "Contenido relacionado",
+    "related-content-loading": "Cargando contenido relacionado",
     "error-title": "Error",
     "error-text": "Ha ocurrido un error.",
     "page-not-found-title": "Página no encontrada",
@@ -97,7 +99,8 @@
       "related-events": "Otros eventos",
       "go-to-events": "Ir a eventos",
       "upcoming": "Próximos eventos",
-      "past": "Eventos anteriores"
+      "past": "Eventos anteriores",
+      "loading": "Cargando el Calendario..."
     },
     "gallery": {
       "about-the-image": "Acerca de la imagen",
@@ -107,6 +110,7 @@
       "additional-information": "Información adicional",
       "available-sizes": "Tamaños disponibles",
       "curated-slideshows": "Presentaciones curadas",
+      "loading-slideshows": "Cargando las Presentaciones...",
       "download-image": "Descargar imagen",
       "download-video": "Descargar video",
       "download-3d": "Descargar modelo 3D",
@@ -138,17 +142,20 @@
       "1080p": "1080p",
       "720p": "720p",
       "480p": "480p",
-      "320p": "320p"
+      "320p": "320p",
+      "loading": "Cargando la Galería..."
     },
     "jobs": {
       "jobs": "Trabajos",
       "read-more": "Leer más sobre este trabajo.",
       "open": "Vacante",
-      "closed": "Cerrado"
+      "closed": "Cerrado",
+      "loading": "Cargando los Trabajos..."
     },
     "news": {
       "related-posts": "Noticias relacionadas",
-      "back-to-posts": "Volver a noticias"
+      "back-to-posts": "Volver a noticias",
+      "loading": "Cargando las noticias..."
     },
     "pagination": {
       "label": "Paginación",
@@ -172,7 +179,8 @@
       "non-scientific-staff": "Perfil del equipo no científico",
       "browse-more": "Navegar más perfiles",
       "back-to-profiles": "Volver a perfiles",
-      "trading-card": "Carta coleccionable"
+      "trading-card": "Carta coleccionable",
+      "loading": "Cargando las Voces de Rubin..."
     },
     "telescope": {
       "state": "Estado",
@@ -301,7 +309,8 @@
       "delete_error_header": "¡Error!"
     },
     "glossary": {
-      "back_button": "Volver al glosario"
+      "back_button": "Volver al glosario",
+      "loading": "Cargando el Glosario..."
     },
     "restricted": {
       "header_approval_pending": "Contenido no disponible aún",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@castiron/style-mixins": "^1.0.6",
     "@headlessui/react": "^1.6.6",
     "@popperjs/core": "^2.11.5",
-    "@rubin-epo/epo-react-lib": "^1.2.5",
+    "@rubin-epo/epo-react-lib": "^1.2.9",
     "add": "^2.0.6",
     "classnames": "^2.3.1",
     "convert": "^4.13.0",
@@ -83,7 +83,7 @@
     "react-popper": "^2.3.0",
     "react-uid": "^2.3.2",
     "striptags": "^3.2.0",
-    "styled-components": "^5.3.5",
+    "styled-components": "5.3.11",
     "swr": "^1.3.0",
     "use-resize-observer": "^9.0.2"
   },

--- a/pages/[[...uriSegments]].js
+++ b/pages/[[...uriSegments]].js
@@ -154,13 +154,7 @@ export async function getStaticProps({ params: { uriSegments }, previewData }) {
   }
 
   const { sectionHandle: section, typeHandle: type } = entrySectionType;
-  const entryData = await getEntryData(
-    uri,
-    section,
-    type,
-    site,
-    previewToken
-  );
+  const entryData = await getEntryData(uri, section, type, site, previewToken);
 
   const currentId = entryData?.id || entryData?.entry?.id;
 

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -2,8 +2,6 @@ import Document, { Html, Head, Main, NextScript } from "next/document";
 import { ServerStyleSheet } from "styled-components";
 import { getSiteString } from "@/lib/utils";
 
-const GOOGLE_APP_ID = process.env.NEXT_PUBLIC_GOOGLE_APP_ID;
-
 class CustomDocument extends Document {
   static async getInitialProps(ctx) {
     const sheet = new ServerStyleSheet();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2387,13 +2387,14 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
   integrity sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==
 
-"@rubin-epo/epo-react-lib@^1.2.5":
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/@rubin-epo/epo-react-lib/-/epo-react-lib-1.2.5.tgz#7100072c15cb3c9eca80fb9cf6e3970ddc22b341"
-  integrity sha512-jGZR5I0bdwAzdq105ZpusyB2e+x+peozrZUvBL98Fna67lxd04nYN3gS5anFaSMSbV4sXGQKdy2VLpGySKnzFw==
+"@rubin-epo/epo-react-lib@^1.2.9":
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/@rubin-epo/epo-react-lib/-/epo-react-lib-1.2.9.tgz#c67c071414f66d1a02381a84974f1b5692595cf5"
+  integrity sha512-JomVC+O9MBiIO5BK8wxLAHT2r1AcwrP6d1Dwus1y+D9Cv2nTDYqcz9uMzRE75azsJ/VLOlLWgZMTom0SwFK60g==
   dependencies:
     flickity "^3.0.0"
-    react-player "^2.11.0"
+    focus-trap "^7.4.2"
+    react-player "^2.12.0"
     react-share "^4.4.1"
     react-slider "^2.0.4"
     react-uid "^2.3.2"
@@ -5780,7 +5781,12 @@ deep-is@^0.1.3, deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
-deepmerge@^4.0.0, deepmerge@^4.2.2:
+deepmerge@^4.0.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
+  integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
+
+deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
@@ -6998,6 +7004,13 @@ focus-trap@^7.0.0:
   integrity sha512-uT4Bl8TwU+5vVAx/DHil/1eVS54k9unqhK/vGy2KSh7esPmqgC0koAB9J2sJ+vtj8+vmiFyGk2unLkhNLQaxoA==
   dependencies:
     tabbable "^6.0.0"
+
+focus-trap@^7.4.2:
+  version "7.4.3"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-7.4.3.tgz#a3dae73d44df359eb92bbf37b18e173e813b16c5"
+  integrity sha512-BgSSbK4GPnS2VbtZ50VtOv1Sti6DIkj3+LkVjiWMNjLeAp1SH1UlLx3ULu/DCu4vq5R4/uvTm+zrvsMsuYmGLg==
+  dependencies:
+    tabbable "^6.1.2"
 
 focus-visible@^5.1.0:
   version "5.2.0"
@@ -10918,10 +10931,10 @@ react-is@^18.0.0, react-is@^18.2.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
-react-player@^2.11.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/react-player/-/react-player-2.11.0.tgz#9afc75314eb915238e8d6615b2891fbe7170aeaa"
-  integrity sha512-fIrwpuXOBXdEg1FiyV9isKevZOaaIsAAtZy5fcjkQK9Nhmk1I2NXzY/hkPos8V0zb/ZX416LFy8gv7l/1k3a5w==
+react-player@^2.12.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/react-player/-/react-player-2.12.0.tgz#2fc05dbfec234c829292fbca563b544064bd14f0"
+  integrity sha512-rymLRz/2GJJD+Wc01S7S+i9pGMFYnNmQibR2gVE3KmHJCBNN8BhPAlOPTGZtn1uKpJ6p4RPLlzPQ1OLreXd8gw==
   dependencies:
     deepmerge "^4.0.0"
     load-script "^1.0.0"
@@ -10958,9 +10971,9 @@ react-share@^4.4.1:
     jsonp "^0.2.1"
 
 react-slider@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/react-slider/-/react-slider-2.0.4.tgz#21c656ffabc3bb4481cf6b49e6d647baeda83572"
-  integrity sha512-sWwQD01n6v+MbeLCYthJGZPc0kzOyhQHyd0bSo0edg+IAxTVQmj3Oy4SBK65eX6gNwS9meUn6Z5sIBUVmwAd9g==
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/react-slider/-/react-slider-2.0.5.tgz#23188e69e8103022370e9dff78cb851d71aef7e1"
+  integrity sha512-MU5gaK1yYCKnbDDN3CMiVcgkKZwMvdqK2xUEW7fFU37NAzRgS1FZbF9N7vP08E3XXNVhiuZnwVzUa3PYQAZIMg==
   dependencies:
     prop-types "^15.8.1"
 
@@ -12008,10 +12021,10 @@ style-search@^0.1.0:
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
   integrity sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==
 
-styled-components@^5.3.5, styled-components@^5.3.6:
-  version "5.3.6"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.3.6.tgz#27753c8c27c650bee9358e343fc927966bfd00d1"
-  integrity sha512-hGTZquGAaTqhGWldX7hhfzjnIYBZ0IXQXkCYdvF1Sq3DsUaLx6+NTHC5Jj1ooM2F68sBiVz3lvhfwQs/S3l6qg==
+styled-components@5.3.11, styled-components@^5.3.6:
+  version "5.3.11"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.3.11.tgz#9fda7bf1108e39bf3f3e612fcc18170dedcd57a8"
+  integrity sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     "@babel/traverse" "^7.4.5"
@@ -12216,6 +12229,11 @@ tabbable@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.0.1.tgz#427a09b13c83ae41eed3e88abb76a4af28bde1a6"
   integrity sha512-SYJSIgeyXW7EuX1ytdneO5e8jip42oHWg9xl/o3oTYhmXusZVgiA+VlPvjIN+kHii9v90AmzTZEBcsEvuAY+TA==
+
+tabbable@^6.1.2:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.1.2.tgz#b0d3ca81d582d48a80f71b267d1434b1469a3703"
+  integrity sha512-qCN98uP7i9z0fIS4amQ5zbGBOq+OSigYeGvPy7NDk8Y9yncqDZ9pRPgfsc2PJIVM9RrJj7GIfuRgmjoUU9zTHQ==
 
 table@^6.8.1:
   version "6.8.1"


### PR DESCRIPTION
Loader graphic implemented across "dynamic" `dataList` and `gridBlock` components.  Loader should appear on page load, then be removed after successful data fetch.  Please review on pages with dynamic dataLists:

- /news
- /explore/voices/all-rubin-voices
- /calendar
- /gallery/slideshows
- /education/glossary
- /about/work-with-us/jobs (n.b. this page is currently disabled but there are jobs entries, so can be reviewed on local if page is reenabled)
- /search?search=space&page=1

and also on pages that have dynamic contentBlocks:
 - a news post (the "related" section at the bottom)
 - an event (the "related" section at the bottom)
 - a Rubin Voices page with a "related" block
 - a normal page with a "related" block
 - homepage (news block at the bottom)