### PR TITLE
[F] SummitStatus modal + weather widgets setup

### DIFF
--- a/components/atomic/Loader/styles.js
+++ b/components/atomic/Loader/styles.js
@@ -5,4 +5,5 @@ export const Loader = styled(CircularLoader)`
   display: flex;
   justify-content: center;
   align-items: center;
+  grid-column: 1/-1;
 `;

--- a/components/content-blocks/SummitStatus/index.js
+++ b/components/content-blocks/SummitStatus/index.js
@@ -1,155 +1,22 @@
 import PropTypes from "prop-types";
-import { useState, Suspense } from "react";
 import { Container } from "@rubin-epo/epo-react-lib";
-import { useTranslation } from "react-i18next";
-import WeatherUnitContext from "@/contexts/WeatherUnit";
+import { WeatherUnitProvider } from "@/contexts/WeatherUnit";
 import UnitLocalization from "@/components/layout/UnitLocalization";
 import WidgetGrid from "@/components/layout/WidgetGrid";
-import WidgetPreview from "@/components/layout/WidgetPreview";
-<<<<<<< HEAD
-=======
-import TemperatureCurrent from "@/components/widgets/CurrentData/patterns/Temperature";
-import TemperatureHistoric from "@/components/widgets/TemperatureHistoric";
-import WindspeedHourly from "@/components/widgets/HourlyData/patterns/Windspeed";
-import PrecipitationHourly from "@/components/widgets/HourlyData/patterns/Precipitation";
->>>>>>> ebb054c ([F] SummitData provider)
 import { SummitDataProvider } from "@/contexts/SummitData";
 import Weather from "@/components/dynamic/SummitData/Weather";
 
 const SummitStatus = ({ summitStatusLayout, widgetPreviews = [] }) => {
-  /** this logic should be changed to useRouter after i18n refactor */
-  const {
-    i18n: { language = "en" },
-  } = useTranslation();
-  const [windspeedUnit, setWindspeedUnit] = useState(
-    language === "en" ? "NM" : "m"
-  );
-  const [tempUnit, setTempUnit] = useState(
-    language === "en" ? "fahrenheit" : "celsius"
-  );
-
-  const mockWindspeedData = [
-    { windspeed: 5.2342342, direction: 120 },
-    { windspeed: 4.7, direction: 112 },
-    { windspeed: 6.1, direction: 98 },
-    { windspeed: 3.8, direction: 105 },
-    { windspeed: 5.5, direction: 117 },
-    { windspeed: 7.2, direction: 125 },
-    { windspeed: 4.3, direction: 103 },
-    { windspeed: 6.8, direction: 108 },
-    { windspeed: 5.14343, direction: 115 },
-    { windspeed: 4.9, direction: 98 },
-    { windspeed: 5.7, direction: 105 },
-    { windspeed: 6.5, direction: 114 },
-    { windspeed: 3.9, direction: 99 },
-    { windspeed: 4.1, direction: 102 },
-    { windspeed: 5.3, direction: 108 },
-    { windspeed: 6.3, direction: 116 },
-    {},
-    {},
-    {},
-    {},
-    {},
-    {},
-    {},
-    {},
-  ];
-
-  const mockPrecipitationData = [
-    { probability: 0.0 },
-    { probability: 0.0 },
-    { probability: 0.0 },
-    { probability: 0.0 },
-    { probability: 0.0 },
-    { probability: 0.0 },
-    { probability: 0.0 },
-    { probability: 0.0 },
-    { probability: 0.01 },
-    { probability: 0.02 },
-    { probability: 0.03 },
-    { probability: 0.04 },
-    { probability: 0.05 },
-    { probability: 0.03 },
-    { probability: 0.02 },
-    { probability: 0.1 },
-    { probability: 0.04 },
-    { probability: 0.03 },
-    { probability: 0.0 },
-    { probability: 0.02 },
-    { probability: 0.01 },
-    { probability: 0.02 },
-    { probability: 0.03 },
-    { probability: 0.02 },
-  ];
-
-  const timedWindpeedData = mockWindspeedData.map(
-    ({ windspeed, direction }, i) => {
-      return { windspeed, direction, time: new Date().setHours(i, 0, 0, 0) };
-    }
-  );
-
-  const timedPrecipitationData = mockPrecipitationData.map(
-    ({ probability }, i) => {
-      return { probability, time: new Date().setHours(i, 0, 0, 0) };
-    }
-  );
-
-  // const [data, loading] = useEfd();
-  // eslint-disable-next-line no-console
-  // console.log({ data, loading });
   return (
     <Container bgColor="neutral95" width="wide" paddingSize="small">
-      <WeatherUnitContext.Provider value={{ tempUnit, windspeedUnit }}>
-        <UnitLocalization
-          {...{ tempUnit, windspeedUnit }}
-          onTempChangeCallback={(value) => setTempUnit(value)}
-          onWindChangeCallback={(value) => setWindspeedUnit(value)}
-        />
+      <WeatherUnitProvider>
+        <UnitLocalization />
         <SummitDataProvider>
           <WidgetGrid>
-<<<<<<< HEAD
-            <WidgetPreview
-              title="Weather at the summit"
-              callout="It is nice out there!"
-            >
-              <Weather />
-            </WidgetPreview>
-=======
             <Weather />
-            {/* <WidgetPreview>
-              <TemperatureCurrent unit={tempUnit} temperature={23.9349824} />
-              <PrecipitationCurrent
-                precipitation={0.0354}
-                humidity={0.45234991292923}
-              />
-            </WidgetPreview>
-            <WidgetPreview size="large">
-              <TemperatureHistoric
-                temperatureData={[
-                  { weekday: 1, high: 23, low: 15 },
-                  { weekday: 2, high: 26, low: 17 },
-                  { weekday: 3, high: 28, low: 15 },
-                  { weekday: 4, high: 31, low: 16 },
-                  { weekday: 5, high: 29, low: 14 },
-                  { weekday: 6, high: 29, low: 11 },
-                  { weekday: 0, high: 32, low: 14 },
-                ]}
-                unit={tempUnit}
-              />
-            </WidgetPreview>
-            <WidgetPreview size="large">
-              <WindspeedHourly
-                unit={windspeedUnit}
-                windspeedData={timedWindpeedData}
-              />
-            </WidgetPreview>
-            <WidgetPreview size="large">
-              <PrecipitationHourly precipitationData={timedPrecipitationData} />
-            </WidgetPreview> */}
->>>>>>> ebb054c ([F] SummitData provider)
           </WidgetGrid>
         </SummitDataProvider>
-      </WeatherUnitContext.Provider>
+      </WeatherUnitProvider>
     </Container>
   );
 };

--- a/components/content-blocks/SummitStatus/index.js
+++ b/components/content-blocks/SummitStatus/index.js
@@ -1,11 +1,18 @@
 import PropTypes from "prop-types";
-import { useState } from "react";
+import { useState, Suspense } from "react";
 import { Container } from "@rubin-epo/epo-react-lib";
 import { useTranslation } from "react-i18next";
 import WeatherUnitContext from "@/contexts/WeatherUnit";
 import UnitLocalization from "@/components/layout/UnitLocalization";
 import WidgetGrid from "@/components/layout/WidgetGrid";
 import WidgetPreview from "@/components/layout/WidgetPreview";
+<<<<<<< HEAD
+=======
+import TemperatureCurrent from "@/components/widgets/CurrentData/patterns/Temperature";
+import TemperatureHistoric from "@/components/widgets/TemperatureHistoric";
+import WindspeedHourly from "@/components/widgets/HourlyData/patterns/Windspeed";
+import PrecipitationHourly from "@/components/widgets/HourlyData/patterns/Precipitation";
+>>>>>>> ebb054c ([F] SummitData provider)
 import { SummitDataProvider } from "@/contexts/SummitData";
 import Weather from "@/components/dynamic/SummitData/Weather";
 
@@ -87,9 +94,9 @@ const SummitStatus = ({ summitStatusLayout, widgetPreviews = [] }) => {
     }
   );
 
-  const [data, loading] = useEfd();
+  // const [data, loading] = useEfd();
   // eslint-disable-next-line no-console
-  console.log({ data, loading });
+  // console.log({ data, loading });
   return (
     <Container bgColor="neutral95" width="wide" paddingSize="small">
       <WeatherUnitContext.Provider value={{ tempUnit, windspeedUnit }}>
@@ -100,12 +107,46 @@ const SummitStatus = ({ summitStatusLayout, widgetPreviews = [] }) => {
         />
         <SummitDataProvider>
           <WidgetGrid>
+<<<<<<< HEAD
             <WidgetPreview
               title="Weather at the summit"
               callout="It is nice out there!"
             >
               <Weather />
             </WidgetPreview>
+=======
+            <Weather />
+            {/* <WidgetPreview>
+              <TemperatureCurrent unit={tempUnit} temperature={23.9349824} />
+              <PrecipitationCurrent
+                precipitation={0.0354}
+                humidity={0.45234991292923}
+              />
+            </WidgetPreview>
+            <WidgetPreview size="large">
+              <TemperatureHistoric
+                temperatureData={[
+                  { weekday: 1, high: 23, low: 15 },
+                  { weekday: 2, high: 26, low: 17 },
+                  { weekday: 3, high: 28, low: 15 },
+                  { weekday: 4, high: 31, low: 16 },
+                  { weekday: 5, high: 29, low: 14 },
+                  { weekday: 6, high: 29, low: 11 },
+                  { weekday: 0, high: 32, low: 14 },
+                ]}
+                unit={tempUnit}
+              />
+            </WidgetPreview>
+            <WidgetPreview size="large">
+              <WindspeedHourly
+                unit={windspeedUnit}
+                windspeedData={timedWindpeedData}
+              />
+            </WidgetPreview>
+            <WidgetPreview size="large">
+              <PrecipitationHourly precipitationData={timedPrecipitationData} />
+            </WidgetPreview> */}
+>>>>>>> ebb054c ([F] SummitData provider)
           </WidgetGrid>
         </SummitDataProvider>
       </WeatherUnitContext.Provider>

--- a/components/content-blocks/SummitStatus/index.js
+++ b/components/content-blocks/SummitStatus/index.js
@@ -87,6 +87,9 @@ const SummitStatus = ({ summitStatusLayout, widgetPreviews = [] }) => {
     }
   );
 
+  const [data, loading] = useEfd();
+  // eslint-disable-next-line no-console
+  console.log({ data, loading });
   return (
     <Container bgColor="neutral95" width="wide" paddingSize="small">
       <WeatherUnitContext.Provider value={{ tempUnit, windspeedUnit }}>

--- a/components/dynamic/SummitData/Weather/Current/index.js
+++ b/components/dynamic/SummitData/Weather/Current/index.js
@@ -20,7 +20,7 @@ const CurrentWeather = () => {
     isOpen,
   };
 
-  if (loading && !currentData)
+  if (loading || !currentData)
     return (
       <WidgetSection {...sectionProps}>
         <Loader isVisible={true} />

--- a/components/dynamic/SummitData/Weather/Current/index.js
+++ b/components/dynamic/SummitData/Weather/Current/index.js
@@ -13,7 +13,10 @@ const CurrentWeather = () => {
   const { t } = useTranslation();
   const [isOpen, setOpen] = useState(true);
   const [{ tempUnit, windspeedUnit }] = useWeatherUnit();
-  const { currentData, loading = true } = useSummitData();
+  const {
+    currentData,
+    loading: { currentData: loading },
+  } = useSummitData();
   const sectionProps = {
     title: t("summit_dashboard.sections.weather.current"),
     onToggleCallback: (value) => setOpen(value),

--- a/components/dynamic/SummitData/Weather/Current/index.js
+++ b/components/dynamic/SummitData/Weather/Current/index.js
@@ -1,0 +1,47 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useWeatherUnit } from "@/contexts/WeatherUnit";
+import { useSummitData } from "@/contexts/SummitData";
+import Loader from "@/components/atomic/Loader";
+import WidgetSection from "@/components/layout/WidgetSection";
+import TemperatureCurrent from "@/components/widgets/CurrentData/patterns/Temperature";
+import WindspeedCurrent from "@/components/widgets/CurrentData/patterns/Windspeed";
+import PrecipitationCurrent from "@/components/widgets/CurrentData/patterns/Precipitation";
+import { convertTemperature, convertWindspeed } from "@/helpers/converters";
+
+const CurrentWeather = () => {
+  const { t } = useTranslation();
+  const [isOpen, setOpen] = useState(true);
+  const [{ tempUnit, windspeedUnit }] = useWeatherUnit();
+  const { currentData, loading = true } = useSummitData();
+  const sectionProps = {
+    title: t("summit_dashboard.sections.weather.current"),
+    onToggleCallback: (value) => setOpen(value),
+    isOpen,
+  };
+
+  if (loading && !currentData)
+    return (
+      <WidgetSection {...sectionProps}>
+        <Loader isVisible={true} />
+      </WidgetSection>
+    );
+
+  const { temperature0, windspeed, relativeHumidity } = currentData;
+  const temperature = convertTemperature(temperature0, tempUnit);
+
+  return (
+    <WidgetSection {...sectionProps}>
+      <TemperatureCurrent unit={tempUnit} temperature={temperature} />
+      <WindspeedCurrent
+        unit={windspeedUnit}
+        windspeed={convertWindspeed(windspeed, windspeedUnit)}
+      />
+      <PrecipitationCurrent humidity={relativeHumidity / 100} />
+    </WidgetSection>
+  );
+};
+
+CurrentWeather.displayName = "Dynamic.Weather.Current";
+
+export default CurrentWeather;

--- a/components/dynamic/SummitData/Weather/Daily/index.js
+++ b/components/dynamic/SummitData/Weather/Daily/index.js
@@ -1,0 +1,49 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useWeatherUnit } from "@/contexts/WeatherUnit";
+import { useSummitData } from "@/contexts/SummitData";
+import Loader from "@/components/atomic/Loader";
+import WidgetSection from "@/components/layout/WidgetSection";
+import TemperatureHistoric from "@/components/widgets/TemperatureHistoric";
+import { convertTemperature } from "@/helpers/converters";
+
+const DailyWeather = () => {
+  const { t } = useTranslation();
+  const [isOpen, setOpen] = useState(true);
+  const [{ tempUnit }] = useWeatherUnit();
+  const { dailyData, loading = true } = useSummitData();
+  const sectionProps = {
+    title: t("summit_dashboard.sections.daily", {
+      unit: t(`summit_dashboard.unit_localization.${tempUnit}`),
+    }),
+    onToggleCallback: (value) => setOpen(value),
+    isOpen,
+  };
+
+  if (loading && !dailyData)
+    return (
+      <WidgetSection {...sectionProps}>
+        <Loader isVisible={true} />
+      </WidgetSection>
+    );
+
+  const temperatureData = dailyData
+    .slice(0, -1)
+    .map(({ _time, temperature0_max, temperature0_min }) => {
+      return {
+        weekday: new Date(_time).getDay(),
+        low: convertTemperature(temperature0_min, tempUnit),
+        high: convertTemperature(temperature0_max, tempUnit),
+      };
+    });
+
+  return (
+    <WidgetSection {...sectionProps}>
+      <TemperatureHistoric unit={tempUnit} temperatureData={temperatureData} />
+    </WidgetSection>
+  );
+};
+
+DailyWeather.displayName = "Dynamic.Weather.Daily";
+
+export default DailyWeather;

--- a/components/dynamic/SummitData/Weather/Daily/index.js
+++ b/components/dynamic/SummitData/Weather/Daily/index.js
@@ -20,7 +20,7 @@ const DailyWeather = () => {
     isOpen,
   };
 
-  if (loading && !dailyData)
+  if (loading || !dailyData)
     return (
       <WidgetSection {...sectionProps}>
         <Loader isVisible={true} />

--- a/components/dynamic/SummitData/Weather/Daily/index.js
+++ b/components/dynamic/SummitData/Weather/Daily/index.js
@@ -13,7 +13,7 @@ const DailyWeather = () => {
   const [{ tempUnit }] = useWeatherUnit();
   const { dailyData, loading = true } = useSummitData();
   const sectionProps = {
-    title: t("summit_dashboard.sections.daily", {
+    title: t("summit_dashboard.sections.weather.daily", {
       unit: t(`summit_dashboard.unit_localization.${tempUnit}`),
     }),
     onToggleCallback: (value) => setOpen(value),

--- a/components/dynamic/SummitData/Weather/Daily/index.js
+++ b/components/dynamic/SummitData/Weather/Daily/index.js
@@ -11,7 +11,10 @@ const DailyWeather = () => {
   const { t } = useTranslation();
   const [isOpen, setOpen] = useState(true);
   const [{ tempUnit }] = useWeatherUnit();
-  const { dailyData, loading = true } = useSummitData();
+  const {
+    dailyData,
+    loading: { dailyData: loading },
+  } = useSummitData();
   const sectionProps = {
     title: t("summit_dashboard.sections.weather.daily", {
       unit: t(`summit_dashboard.unit_localization.${tempUnit}`),

--- a/components/dynamic/SummitData/Weather/Daily/index.js
+++ b/components/dynamic/SummitData/Weather/Daily/index.js
@@ -29,11 +29,11 @@ const DailyWeather = () => {
 
   const temperatureData = dailyData
     .slice(0, -1)
-    .map(({ _time, temperature0_max, temperature0_min }) => {
+    .map(({ _time, temperature0_max: max, temperature0_min: min }) => {
       return {
         weekday: new Date(_time).getDay(),
-        low: convertTemperature(temperature0_min, tempUnit),
-        high: convertTemperature(temperature0_max, tempUnit),
+        low: convertTemperature(min, tempUnit),
+        high: convertTemperature(max, tempUnit),
       };
     });
 

--- a/components/dynamic/SummitData/Weather/Hourly/index.js
+++ b/components/dynamic/SummitData/Weather/Hourly/index.js
@@ -13,7 +13,7 @@ const HourlyWeather = () => {
   const [{ windspeedUnit }] = useWeatherUnit();
   const { hourlyData, loading = true } = useSummitData();
   const sectionProps = {
-    title: t("summit_dashboard.sections.hourly"),
+    title: t("summit_dashboard.sections.weather.hourly"),
     onToggleCallback: (value) => setOpen(value),
     isOpen,
   };

--- a/components/dynamic/SummitData/Weather/Hourly/index.js
+++ b/components/dynamic/SummitData/Weather/Hourly/index.js
@@ -27,11 +27,11 @@ const HourlyWeather = () => {
 
   const windspeedData = hourlyData
     .slice(0, -1)
-    .map(({ _time, direction_mean: direction, speed_mean }) => {
+    .map(({ _time, direction_mean: direction, speed_mean: windspeed }) => {
       return {
         direction,
         time: new Date(_time),
-        windspeed: convertWindspeed(speed_mean, windspeedUnit),
+        windspeed: convertWindspeed(windspeed, windspeedUnit),
       };
     });
 

--- a/components/dynamic/SummitData/Weather/Hourly/index.js
+++ b/components/dynamic/SummitData/Weather/Hourly/index.js
@@ -11,7 +11,10 @@ const HourlyWeather = () => {
   const { t } = useTranslation();
   const [isOpen, setOpen] = useState(true);
   const [{ windspeedUnit }] = useWeatherUnit();
-  const { hourlyData, loading = true } = useSummitData();
+  const {
+    hourlyData,
+    loading: { hourlyData: loading },
+  } = useSummitData();
   const sectionProps = {
     title: t("summit_dashboard.sections.weather.hourly"),
     onToggleCallback: (value) => setOpen(value),

--- a/components/dynamic/SummitData/Weather/Hourly/index.js
+++ b/components/dynamic/SummitData/Weather/Hourly/index.js
@@ -18,7 +18,7 @@ const HourlyWeather = () => {
     isOpen,
   };
 
-  if (loading && !hourlyData)
+  if (loading || !hourlyData)
     return (
       <WidgetSection {...sectionProps}>
         <Loader isVisible={true} />

--- a/components/dynamic/SummitData/Weather/Hourly/index.js
+++ b/components/dynamic/SummitData/Weather/Hourly/index.js
@@ -1,0 +1,47 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useWeatherUnit } from "@/contexts/WeatherUnit";
+import { useSummitData } from "@/contexts/SummitData";
+import Loader from "@/components/atomic/Loader";
+import WidgetSection from "@/components/layout/WidgetSection";
+import Windspeed from "@/components/widgets/HourlyData/patterns/Windspeed";
+import { convertWindspeed } from "@/helpers/converters";
+
+const HourlyWeather = () => {
+  const { t } = useTranslation();
+  const [isOpen, setOpen] = useState(true);
+  const [{ windspeedUnit }] = useWeatherUnit();
+  const { hourlyData, loading = true } = useSummitData();
+  const sectionProps = {
+    title: t("summit_dashboard.sections.hourly"),
+    onToggleCallback: (value) => setOpen(value),
+    isOpen,
+  };
+
+  if (loading && !hourlyData)
+    return (
+      <WidgetSection {...sectionProps}>
+        <Loader isVisible={true} />
+      </WidgetSection>
+    );
+
+  const windspeedData = hourlyData
+    .slice(0, -1)
+    .map(({ _time, direction_mean: direction, speed_mean }) => {
+      return {
+        direction,
+        time: new Date(_time),
+        windspeed: convertWindspeed(speed_mean, windspeedUnit),
+      };
+    });
+
+  return (
+    <WidgetSection {...sectionProps}>
+      <Windspeed unit={windspeedUnit} windspeedData={windspeedData} />
+    </WidgetSection>
+  );
+};
+
+HourlyWeather.displayName = "Dynamic.Weather.Hourly";
+
+export default HourlyWeather;

--- a/components/dynamic/SummitData/Weather/index.js
+++ b/components/dynamic/SummitData/Weather/index.js
@@ -22,12 +22,14 @@ const Weather = () => {
     title: t("summit_dashboard.sections.weather.preview"),
   };
 
-  if (loading && !currentData)
+  if (loading || !currentData)
     return (
       <WidgetPreview {...previewProps}>
         <Loader isVisible={true} />
       </WidgetPreview>
     );
+
+  console.log({ currentData });
 
   const { temperature0, relativeHumidity } = currentData;
   const temperature = convertTemperature(temperature0, tempUnit);

--- a/components/dynamic/SummitData/Weather/index.js
+++ b/components/dynamic/SummitData/Weather/index.js
@@ -1,29 +1,29 @@
 import { useState } from "react";
-<<<<<<< HEAD
 import Loader from "@/components/atomic/Loader";
 import WidgetPreview from "@/components/layout/WidgetPreview";
-import WidgetSection from "@/components/layout/WidgetSection";
 import SummitStatusModal from "@/components/modal/SummitStatusModal";
-import PrecipitationCurrent from "@/components/widgets/PrecipitationCurrent";
-import TemperatureCurrent from "@/components/widgets/TemperatureCurrent";
->>>>>>> ebb054c ([F] SummitData provider)
+import PrecipitationCurrent from "@/components/widgets/CurrentData/patterns/Precipitation";
+import TemperatureCurrent from "@/components/widgets/CurrentData/patterns/Temperature";
 import { useSummitData } from "@/contexts/SummitData";
 import { useWeatherUnit } from "@/contexts/WeatherUnit";
 import { convertTemperature } from "@/helpers/converters";
 import DailyWeather from "./Daily";
 import HourlyWeather from "./Hourly";
+import CurrentWeather from "./Current";
 
 const Weather = () => {
+  const { t } = useTranslation();
   const [isModalOpen, setModalOpen] = useState(false);
   const [{ tempUnit, windspeedUnit }] = useWeatherUnit();
   const { currentData, loading = true } = useSummitData();
 
+  const previewProps = {
+    title: t("summit_dashboard.sections.weather.preview"),
+  };
+
   if (loading && !currentData)
     return (
-      <WidgetPreview
-        title="Weather at the summit"
-        callout="It is nice out there!"
-      >
+      <WidgetPreview {...previewProps}>
         <Loader isVisible={true} />
       </WidgetPreview>
     );
@@ -33,8 +33,7 @@ const Weather = () => {
 
   return (
     <WidgetPreview
-      title="Weather at the summit"
-      callout="It is nice out there!"
+      {...previewProps}
       openModalCallback={() => {
         setModalOpen(true);
       }}
@@ -46,10 +45,7 @@ const Weather = () => {
         onClose={() => setModalOpen(false)}
         {...{ tempUnit, windspeedUnit }}
       >
-        <WidgetSection title="Weather at the summit now">
-          <TemperatureCurrent unit={tempUnit} temperature={temperature} />
-          <PrecipitationCurrent humidity={relativeHumidity / 100} />
-        </WidgetSection>
+        <CurrentWeather />
         <HourlyWeather />
         <DailyWeather />
       </SummitStatusModal>

--- a/components/dynamic/SummitData/Weather/index.js
+++ b/components/dynamic/SummitData/Weather/index.js
@@ -1,12 +1,18 @@
+<<<<<<< HEAD
 import Loader from "@/components/atomic/Loader";
 import PrecipitationCurrent from "@/components/widgets/CurrentData/patterns/Precipitation";
 import TemperatureCurrent from "@/components/widgets/CurrentData/patterns/Temperature";
+=======
+import WidgetPreview from "@/components/layout/WidgetPreview";
+import TemperatureCurrent from "@/components/widgets/TemperatureCurrent";
+>>>>>>> ebb054c ([F] SummitData provider)
 import { useSummitData } from "@/contexts/SummitData";
 import { defaultUnits, useWeatherUnit } from "@/contexts/WeatherUnit";
 import convert from "convert";
 
 const Weather = () => {
   const { tempUnit, windspeedUnit } = useWeatherUnit();
+<<<<<<< HEAD
   const { currentData: data, loading = true } = useSummitData();
 
   if (loading && !data) return <Loader isVisible={true} />;
@@ -22,11 +28,27 @@ const Weather = () => {
   };
 
   if (tempUnit !== defaultUnits.tempUnit) {
+=======
+  const { data, loading } = useSummitData();
+
+  if (loading || !data) return null;
+
+  console.log({ data });
+
+  const {
+    temperature0: { _value: currentTemperature },
+  } = data;
+
+  const temperatureData = { currentTemperature };
+
+  if ({ tempUnit, windspeedUnit } !== defaultUnits) {
+>>>>>>> ebb054c ([F] SummitData provider)
     Object.entries(temperatureData).forEach(([key, value]) => {
       temperatureData[key] = convert(value, defaultUnits.tempUnit).to(tempUnit);
     });
   }
 
+<<<<<<< HEAD
   if (windspeedUnit !== defaultUnits.windspeedUnit) {
     Object.entries(windspeedData).forEach(([key, value]) => {
       windspeedData[key] = convert(value, defaultUnits.windspeedUnit).to(
@@ -43,6 +65,18 @@ const Weather = () => {
       />
       <PrecipitationCurrent humidity={relativeHumidity / 100} />
     </>
+=======
+  return (
+    <WidgetPreview
+      title="Weather at the summit"
+      callout="It is nice out there!"
+    >
+      <TemperatureCurrent
+        unit={tempUnit}
+        temperature={temperatureData.currentTemperature}
+      />
+    </WidgetPreview>
+>>>>>>> ebb054c ([F] SummitData provider)
   );
 };
 

--- a/components/dynamic/SummitData/Weather/index.js
+++ b/components/dynamic/SummitData/Weather/index.js
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import Loader from "@/components/atomic/Loader";
 import WidgetPreview from "@/components/layout/WidgetPreview";
 import SummitStatusModal from "@/components/modal/SummitStatusModal";

--- a/components/dynamic/SummitData/Weather/index.js
+++ b/components/dynamic/SummitData/Weather/index.js
@@ -1,82 +1,59 @@
+import { useState } from "react";
 <<<<<<< HEAD
 import Loader from "@/components/atomic/Loader";
-import PrecipitationCurrent from "@/components/widgets/CurrentData/patterns/Precipitation";
-import TemperatureCurrent from "@/components/widgets/CurrentData/patterns/Temperature";
-=======
 import WidgetPreview from "@/components/layout/WidgetPreview";
+import WidgetSection from "@/components/layout/WidgetSection";
+import SummitStatusModal from "@/components/modal/SummitStatusModal";
+import PrecipitationCurrent from "@/components/widgets/PrecipitationCurrent";
 import TemperatureCurrent from "@/components/widgets/TemperatureCurrent";
 >>>>>>> ebb054c ([F] SummitData provider)
 import { useSummitData } from "@/contexts/SummitData";
-import { defaultUnits, useWeatherUnit } from "@/contexts/WeatherUnit";
-import convert from "convert";
+import { useWeatherUnit } from "@/contexts/WeatherUnit";
+import { convertTemperature } from "@/helpers/converters";
+import DailyWeather from "./Daily";
+import HourlyWeather from "./Hourly";
 
 const Weather = () => {
-  const { tempUnit, windspeedUnit } = useWeatherUnit();
-<<<<<<< HEAD
-  const { currentData: data, loading = true } = useSummitData();
+  const [isModalOpen, setModalOpen] = useState(false);
+  const [{ tempUnit, windspeedUnit }] = useWeatherUnit();
+  const { currentData, loading = true } = useSummitData();
 
-  if (loading && !data) return <Loader isVisible={true} />;
+  if (loading && !currentData)
+    return (
+      <WidgetPreview
+        title="Weather at the summit"
+        callout="It is nice out there!"
+      >
+        <Loader isVisible={true} />
+      </WidgetPreview>
+    );
 
-  const { temperature0: temperature, relativeHumidity, windSpeed } = data;
+  const { temperature0, relativeHumidity } = currentData;
+  const temperature = convertTemperature(temperature0, tempUnit);
 
-  const temperatureData = {
-    temperature,
-  };
-
-  const windspeedData = {
-    windSpeed,
-  };
-
-  if (tempUnit !== defaultUnits.tempUnit) {
-=======
-  const { data, loading } = useSummitData();
-
-  if (loading || !data) return null;
-
-  console.log({ data });
-
-  const {
-    temperature0: { _value: currentTemperature },
-  } = data;
-
-  const temperatureData = { currentTemperature };
-
-  if ({ tempUnit, windspeedUnit } !== defaultUnits) {
->>>>>>> ebb054c ([F] SummitData provider)
-    Object.entries(temperatureData).forEach(([key, value]) => {
-      temperatureData[key] = convert(value, defaultUnits.tempUnit).to(tempUnit);
-    });
-  }
-
-<<<<<<< HEAD
-  if (windspeedUnit !== defaultUnits.windspeedUnit) {
-    Object.entries(windspeedData).forEach(([key, value]) => {
-      windspeedData[key] = convert(value, defaultUnits.windspeedUnit).to(
-        windspeedUnit
-      );
-    });
-  }
-
-  return (
-    <>
-      <TemperatureCurrent
-        unit={tempUnit}
-        temperature={temperatureData.temperature}
-      />
-      <PrecipitationCurrent humidity={relativeHumidity / 100} />
-    </>
-=======
   return (
     <WidgetPreview
       title="Weather at the summit"
       callout="It is nice out there!"
+      openModalCallback={() => {
+        setModalOpen(true);
+      }}
     >
-      <TemperatureCurrent
-        unit={tempUnit}
-        temperature={temperatureData.currentTemperature}
-      />
+      <TemperatureCurrent unit={tempUnit} temperature={temperature} />
+      <PrecipitationCurrent humidity={relativeHumidity / 100} />
+      <SummitStatusModal
+        open={isModalOpen}
+        onClose={() => setModalOpen(false)}
+        {...{ tempUnit, windspeedUnit }}
+      >
+        <WidgetSection title="Weather at the summit now">
+          <TemperatureCurrent unit={tempUnit} temperature={temperature} />
+          <PrecipitationCurrent humidity={relativeHumidity / 100} />
+        </WidgetSection>
+        <HourlyWeather />
+        <DailyWeather />
+      </SummitStatusModal>
     </WidgetPreview>
->>>>>>> ebb054c ([F] SummitData provider)
   );
 };
 

--- a/components/dynamic/SummitData/Weather/index.js
+++ b/components/dynamic/SummitData/Weather/index.js
@@ -16,7 +16,10 @@ const Weather = () => {
   const { t } = useTranslation();
   const [isModalOpen, setModalOpen] = useState(false);
   const [{ tempUnit, windspeedUnit }] = useWeatherUnit();
-  const { currentData, loading = true } = useSummitData();
+  const {
+    currentData,
+    loading: { currentData: loading },
+  } = useSummitData();
 
   const previewProps = {
     title: t("summit_dashboard.sections.weather.preview"),
@@ -28,8 +31,6 @@ const Weather = () => {
         <Loader isVisible={true} />
       </WidgetPreview>
     );
-
-  console.log({ currentData });
 
   const { temperature0, relativeHumidity } = currentData;
   const temperature = convertTemperature(temperature0, tempUnit);

--- a/components/layout/UnitLocalization/index.js
+++ b/components/layout/UnitLocalization/index.js
@@ -6,14 +6,11 @@ import {
   temperatureUnitType,
   windspeedUnitType,
 } from "@/components/shapes/units";
+import { useWeatherUnit } from "@/contexts/WeatherUnit";
 
-const UnitLocalization = ({
-  tempUnit,
-  windspeedUnit,
-  onTempChangeCallback,
-  onWindChangeCallback,
-}) => {
-  const { t, i18n } = useTranslation();
+const UnitLocalization = () => {
+  const [{ tempUnit, windspeedUnit }, dispatch] = useWeatherUnit();
+  const { t } = useTranslation();
   const heading = "unitLocalizationHeading";
   const temperatureLabel = "temperatureLabel";
   const windspeedLabel = "windspeedLabel";
@@ -50,9 +47,7 @@ const UnitLocalization = ({
       <Styled.RadioGroup
         value={tempUnit}
         aria-labelledby={temperatureLabel}
-        onChange={(value) =>
-          onTempChangeCallback && onTempChangeCallback(value)
-        }
+        onChange={(value) => dispatch({ type: value })}
       >
         <Styled.RadioGroupLabel id={temperatureLabel}>
           {t("summit_dashboard.unit_localization.label_temp")}
@@ -66,9 +61,7 @@ const UnitLocalization = ({
       <Styled.RadioGroup
         value={windspeedUnit}
         aria-labelledby={windspeedLabel}
-        onChange={(value) =>
-          onWindChangeCallback && onWindChangeCallback(value)
-        }
+        onChange={(value) => dispatch({ type: value })}
       >
         <Styled.RadioGroupLabel id={windspeedLabel}>
           {t("summit_dashboard.unit_localization.label_windspeed")}

--- a/components/layout/WidgetSection/index.js
+++ b/components/layout/WidgetSection/index.js
@@ -9,7 +9,7 @@ const WidgetSection = ({
   onToggleCallback,
 }) => {
   const handleToggle = () => {
-    onToggleCallback(!isOpen);
+    onToggleCallback && onToggleCallback(!isOpen);
   };
 
   return (

--- a/components/layout/WidgetSection/styles.js
+++ b/components/layout/WidgetSection/styles.js
@@ -1,4 +1,5 @@
 import IconButton from "@/components/atomic/Button/IconButton";
+import { BREAK_PHABLET_MIN } from "@/styles/globalStyles";
 import styled from "styled-components";
 
 export const WidgetSection = styled.section`
@@ -20,7 +21,10 @@ export const WidgetSection = styled.section`
 `;
 
 export const SectionIconButton = styled(IconButton)`
+  text-align: left;
+
   > svg {
+    flex-shrink: 0;
     padding: 7px;
     border: 1px solid var(--section-color);
     border-radius: 50%;
@@ -42,12 +46,18 @@ export const SectionHeader = styled.h2`
 `;
 
 export const SectionContent = styled.div`
+  --grid-columns: repeat(2, 1fr);
+
   grid-gap: var(--PADDING_SMALL, 20px);
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: var(--grid-columns);
   grid-auto-rows: 10rem;
   margin-block-start: var(--PADDING_SMALL, 20px);
 
   &:not([hidden]) {
     display: grid;
+  }
+
+  @media screen and (min-width: ${BREAK_PHABLET_MIN}) {
+    --grid-columns: repeat(4, 1fr);
   }
 `;

--- a/components/layout/WidgetSection/styles.js
+++ b/components/layout/WidgetSection/styles.js
@@ -43,8 +43,8 @@ export const SectionHeader = styled.h2`
 
 export const SectionContent = styled.div`
   grid-gap: var(--PADDING_SMALL, 20px);
-  grid-template-columns: 1fr;
-  grid-auto-rows: min-content;
+  grid-template-columns: repeat(4, 1fr);
+  grid-auto-rows: 10rem;
   margin-block-start: var(--PADDING_SMALL, 20px);
 
   &:not([hidden]) {

--- a/components/modal/SummitStatusModal/index.js
+++ b/components/modal/SummitStatusModal/index.js
@@ -2,13 +2,18 @@ import PropTypes from "prop-types";
 import * as Styled from "./styles";
 import UnitLocalization from "@/components/layout/UnitLocalization";
 
-const SummitStatusModal = ({ open, onClose, children }) => {
+const SummitStatusModal = ({
+  open,
+  onClose,
+  children,
+  showLocalization = true,
+}) => {
   return (
     <Styled.Dialog {...{ open, onClose }}>
       <Styled.Overlay />
       <Styled.Content aria-live="polite">
         <Styled.Toolbar>
-          <UnitLocalization />
+          {showLocalization && <UnitLocalization />}
           <Styled.CloseButton
             type="button"
             aria-label="Close"
@@ -16,8 +21,7 @@ const SummitStatusModal = ({ open, onClose, children }) => {
             icon="close"
           />
         </Styled.Toolbar>
-
-        {children}
+        <Styled.ScrollableContent>{children}</Styled.ScrollableContent>
       </Styled.Content>
     </Styled.Dialog>
   );
@@ -29,6 +33,7 @@ SummitStatusModal.propTypes = {
   open: PropTypes.bool,
   onClose: PropTypes.func.isRequired,
   children: PropTypes.node.isRequired,
+  showLocalization: PropTypes.bool,
 };
 
 export default SummitStatusModal;

--- a/components/modal/SummitStatusModal/index.js
+++ b/components/modal/SummitStatusModal/index.js
@@ -1,0 +1,34 @@
+import PropTypes from "prop-types";
+import * as Styled from "./styles";
+import UnitLocalization from "@/components/layout/UnitLocalization";
+
+const SummitStatusModal = ({ open, onClose, children }) => {
+  return (
+    <Styled.Dialog {...{ open, onClose }}>
+      <Styled.Overlay />
+      <Styled.Content aria-live="polite">
+        <Styled.Toolbar>
+          <UnitLocalization />
+          <Styled.CloseButton
+            type="button"
+            aria-label="Close"
+            onClickCallback={() => onClose && onClose()}
+            icon="close"
+          />
+        </Styled.Toolbar>
+
+        {children}
+      </Styled.Content>
+    </Styled.Dialog>
+  );
+};
+
+SummitStatusModal.displayName = "Modal.SummitStatus";
+
+SummitStatusModal.propTypes = {
+  open: PropTypes.bool,
+  onClose: PropTypes.func.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export default SummitStatusModal;

--- a/components/modal/SummitStatusModal/styles.js
+++ b/components/modal/SummitStatusModal/styles.js
@@ -27,21 +27,40 @@ export const Content = styled.div`
   display: flex;
   flex-direction: column;
   gap: var(--PADDING_SMALL, 20px);
-  max-width: 100vw;
   color: var(--white, #fff);
   width: calc(100vw - 1rem);
   max-width: var(--BREAK_LARGE_TABLET, 850px);
+  max-height: 100%;
+`;
+
+export const ScrollableContent = styled.div`
+  overflow-x: hidden;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--white, #fff) rgba(255, 255, 255, 20%);
+
+  &::-webkit-scrollbar {
+    width: 8px;
+    background-color: rgba(255, 255, 255, 50%); /* or add it to the track */
+    background-clip: padding-box;
+    border-top: 3px solid transparent;
+    border-bottom: 3px solid transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: var(--white, #fff);
+    border-radius: 4px;
+  }
 `;
 
 export const Toolbar = styled.div`
   display: flex;
   align-items: center;
+  justify-content: flex-end;
+  height: min-content;
 `;
 
 export const CloseButton = styled(IconButton)`
-  position: absolute;
-  top: 0;
-  right: 0;
   width: 1rem;
   height: 1rem;
 

--- a/components/modal/SummitStatusModal/styles.js
+++ b/components/modal/SummitStatusModal/styles.js
@@ -1,0 +1,53 @@
+import styled from "styled-components";
+import { zStack } from "@/styles/globalStyles";
+import { Dialog as BaseDialog } from "@headlessui/react";
+import IconButton from "@/components/atomic/Button/IconButton";
+
+export const Overlay = styled(BaseDialog.Overlay)`
+  background-color: rgba(0, 0, 0, 80%);
+  position: fixed;
+  top: 0;
+  width: 100%;
+  height: 100%;
+`;
+
+export const Dialog = styled(BaseDialog)`
+  position: fixed;
+  inset: 0;
+  z-index: ${zStack.dialog};
+  overflow: auto;
+  padding: 1rem;
+  display: flex;
+  align-items: start;
+  justify-content: center;
+`;
+
+export const Content = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--PADDING_SMALL, 20px);
+  max-width: 100vw;
+  color: var(--white, #fff);
+  width: calc(100vw - 1rem);
+  max-width: var(--BREAK_LARGE_TABLET, 850px);
+`;
+
+export const Toolbar = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+export const CloseButton = styled(IconButton)`
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 1rem;
+  height: 1rem;
+
+  &:hover {
+    svg {
+      stroke-width: 10px;
+    }
+  }
+`;

--- a/components/widgets/CurrentData/patterns/Windspeed/index.js
+++ b/components/widgets/CurrentData/patterns/Windspeed/index.js
@@ -1,10 +1,11 @@
 import PropTypes from "prop-types";
-import { windspeedUnitType } from "@/components/shapes/units";
 import { useTranslation } from "react-i18next";
+import { windspeedUnitType } from "@/components/shapes/units";
+import { defaultWindspeedUnit } from "@/contexts/WeatherUnit";
 import WidgetBackground from "@/components/atomic/WidgetBackground";
 import * as Styled from "../../styles";
 
-const WindspeedCurrent = ({ windspeed = 0, unit = "m" }) => {
+const WindspeedCurrent = ({ windspeed = 0, unit = defaultWindspeedUnit }) => {
   const {
     t,
     i18n: { language = "en" },
@@ -18,7 +19,7 @@ const WindspeedCurrent = ({ windspeed = 0, unit = "m" }) => {
       <Styled.Value $variant="large">
         {new Intl.NumberFormat(language, {
           style: "decimal",
-          maximumFractionDigits: 0,
+          maximumFractionDigits: unit === defaultWindspeedUnit ? 1 : 0,
         }).format(windspeed)}
       </Styled.Value>
       <Styled.Unit>

--- a/components/widgets/HourlyData/patterns/Precipitation/index.js
+++ b/components/widgets/HourlyData/patterns/Precipitation/index.js
@@ -18,7 +18,7 @@ const PrecipitationHourly = ({ precipitationData = [] }) => {
         {precipitationData.map(({ probability, time }) => (
           <Styled.PreciptationHourlyItem key={time}>
             <Styled.Time dateTime={formatTime(time, language)}>
-              {new Date(time).getHours() === new Date().getHours() ? (
+              {time.getHours() === new Date().getHours() ? (
                 <strong>
                   {t(
                     "summit_dashboard.weather.condition_now"
@@ -46,7 +46,7 @@ PrecipitationHourly.propTypes = {
   precipitationData: PropTypes.arrayOf(
     PropTypes.shape({
       probability: PropTypes.number,
-      time: PropTypes.number,
+      time: PropTypes.instanceOf(Date),
     })
   ).isRequired,
 };

--- a/components/widgets/HourlyData/patterns/Windspeed/index.js
+++ b/components/widgets/HourlyData/patterns/Windspeed/index.js
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 import { windspeedUnitType } from "@/components/shapes/units";
 import { useTranslation } from "react-i18next";
@@ -7,6 +8,7 @@ import UniqueIconComposer from "@/components/svg/UniqueIconComposer";
 import { ScreenreaderText } from "@rubin-epo/epo-react-lib";
 
 const Windspeed = ({ unit, windspeedData = [], labelledById }) => {
+  const currentTimeRef = useRef();
   const {
     t,
     i18n: { language = "en" },
@@ -40,6 +42,12 @@ const Windspeed = ({ unit, windspeedData = [], labelledById }) => {
       }).toLocaleLowerCase(language)}`,
   };
 
+  useEffect(() => {
+    if (currentTimeRef.current) {
+      currentTimeRef.current.scrollIntoView();
+    }
+  }, []);
+
   return (
     <Styled.HourlyDataBackground>
       <Styled.HourlyDataTitle>
@@ -51,40 +59,47 @@ const Windspeed = ({ unit, windspeedData = [], labelledById }) => {
       </Styled.HourlyDataTitle>
       <Styled.HourlyDataList as="ol" role="list" aria-labelledby={labelledById}>
         {windspeedData &&
-          windspeedData.map(({ windspeed, direction, time }) => (
-            <Styled.HourlyDataItem key={time} role="listitem">
-              <Styled.Time dateTime={formatTime(time, language)}>
-                {time.getHours() === new Date().getHours() ? (
-                  <strong>
-                    {t(
-                      "summit_dashboard.weather.condition_now"
-                    ).toLocaleUpperCase(language)}
-                  </strong>
-                ) : (
-                  formatTime(time, language)
-                )}
-              </Styled.Time>
-              <Styled.Direction style={{ "--angle": `${direction}deg` }}>
-                {direction ? (
-                  <>
-                    <UniqueIconComposer icon="arrow" />
-                    <ScreenreaderText>
-                      {t("summit_dashboard.weather.windspeed_direction", {
-                        direction: directionFormatter.format(direction),
-                      })}
-                    </ScreenreaderText>
-                  </>
-                ) : (
-                  <Styled.NoData>
-                    {t("summit_dashboard.weather.no_data_yet")}
-                  </Styled.NoData>
-                )}
-              </Styled.Direction>
-              <Styled.Speed>
-                {windspeed ? speedFormatters[unit](windspeed) : "\u00A0"}
-              </Styled.Speed>
-            </Styled.HourlyDataItem>
-          ))}
+          windspeedData.map(({ windspeed, direction, time }) => {
+            const isNow = time.getHours() === new Date().getHours();
+            return (
+              <Styled.HourlyDataItem
+                key={time}
+                role="listitem"
+                ref={isNow ? currentTimeRef : undefined}
+              >
+                <Styled.Time dateTime={formatTime(time, language)}>
+                  {isNow ? (
+                    <strong>
+                      {t(
+                        "summit_dashboard.weather.condition_now"
+                      ).toLocaleUpperCase(language)}
+                    </strong>
+                  ) : (
+                    formatTime(time, language)
+                  )}
+                </Styled.Time>
+                <Styled.Direction style={{ "--angle": `${direction}deg` }}>
+                  {direction ? (
+                    <>
+                      <UniqueIconComposer icon="arrow" />
+                      <ScreenreaderText>
+                        {t("summit_dashboard.weather.windspeed_direction", {
+                          direction: directionFormatter.format(direction),
+                        })}
+                      </ScreenreaderText>
+                    </>
+                  ) : (
+                    <Styled.NoData>
+                      {t("summit_dashboard.weather.no_data_yet")}
+                    </Styled.NoData>
+                  )}
+                </Styled.Direction>
+                <Styled.Speed>
+                  {windspeed ? speedFormatters[unit](windspeed) : "\u00A0"}
+                </Styled.Speed>
+              </Styled.HourlyDataItem>
+            );
+          })}
       </Styled.HourlyDataList>
     </Styled.HourlyDataBackground>
   );

--- a/components/widgets/HourlyData/patterns/Windspeed/index.js
+++ b/components/widgets/HourlyData/patterns/Windspeed/index.js
@@ -54,7 +54,7 @@ const Windspeed = ({ unit, windspeedData = [], labelledById }) => {
           windspeedData.map(({ windspeed, direction, time }) => (
             <Styled.HourlyDataItem key={time} role="listitem">
               <Styled.Time dateTime={formatTime(time, language)}>
-                {new Date(time).getHours() === new Date().getHours() ? (
+                {time.getHours() === new Date().getHours() ? (
                   <strong>
                     {t(
                       "summit_dashboard.weather.condition_now"
@@ -98,7 +98,7 @@ Windspeed.propTypes = {
     PropTypes.shape({
       windspeed: PropTypes.number,
       direction: PropTypes.number,
-      time: PropTypes.number,
+      time: PropTypes.instanceOf(Date),
     })
   ),
   labelledById: PropTypes.string,

--- a/components/widgets/HourlyData/styles.js
+++ b/components/widgets/HourlyData/styles.js
@@ -21,6 +21,7 @@ export const HourlyDataItem = styled.li`
   display: flex;
   flex-direction: column-reverse;
   justify-content: center;
+  align-items: center;
   text-align: center;
 `;
 

--- a/contexts/SummitData.js
+++ b/contexts/SummitData.js
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
 import {
   currentWeather,
@@ -6,10 +7,15 @@ import {
 } from "@/lib/api/queries/weather";
 import PropTypes from "prop-types";
 import queryEfd from "@/lib/api/efd";
+=======
+import getEfd from "@/lib/api/efd";
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
+>>>>>>> ebb054c ([F] SummitData provider)
 
 export const SummitDataContext = createContext({});
 
 export const SummitDataProvider = ({ children }) => {
+<<<<<<< HEAD
   const [currentData, setCurrentData] = useState();
   const [hourlyData, setHourlyData] = useState();
   const [dailyData, setDailyData] = useState();
@@ -62,6 +68,19 @@ export const SummitDataProvider = ({ children }) => {
     ])
       .catch((e) => {
         console.error(e);
+=======
+  const [data, setData] = useState();
+  const [error, setError] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    getEfd()
+      .then((value) => {
+        setData(value);
+      })
+      .catch(() => {
+>>>>>>> ebb054c ([F] SummitData provider)
         setError(true);
       })
       .finally(() => {
@@ -71,6 +90,7 @@ export const SummitDataProvider = ({ children }) => {
 
   const value = useMemo(
     () => ({
+<<<<<<< HEAD
       currentData,
       hourlyData,
       dailyData,
@@ -78,6 +98,13 @@ export const SummitDataProvider = ({ children }) => {
       error,
     }),
     [currentData, hourlyData, dailyData, loading, error]
+=======
+      data,
+      loading,
+      error,
+    }),
+    [data, loading, error]
+>>>>>>> ebb054c ([F] SummitData provider)
   );
 
   return (
@@ -87,6 +114,9 @@ export const SummitDataProvider = ({ children }) => {
   );
 };
 
+<<<<<<< HEAD
 SummitDataProvider.propTypes = { children: PropTypes.node };
 
+=======
+>>>>>>> ebb054c ([F] SummitData provider)
 export const useSummitData = () => useContext(SummitDataContext);

--- a/contexts/SummitData.js
+++ b/contexts/SummitData.js
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
 import {
   currentWeather,
@@ -7,15 +6,10 @@ import {
 } from "@/lib/api/queries/weather";
 import PropTypes from "prop-types";
 import queryEfd from "@/lib/api/efd";
-=======
-import getEfd from "@/lib/api/efd";
-import { createContext, useContext, useEffect, useMemo, useState } from "react";
->>>>>>> ebb054c ([F] SummitData provider)
 
 export const SummitDataContext = createContext({});
 
 export const SummitDataProvider = ({ children }) => {
-<<<<<<< HEAD
   const [currentData, setCurrentData] = useState();
   const [hourlyData, setHourlyData] = useState();
   const [dailyData, setDailyData] = useState();
@@ -68,19 +62,6 @@ export const SummitDataProvider = ({ children }) => {
     ])
       .catch((e) => {
         console.error(e);
-=======
-  const [data, setData] = useState();
-  const [error, setError] = useState(false);
-  const [loading, setLoading] = useState(false);
-
-  useEffect(() => {
-    setLoading(true);
-    getEfd()
-      .then((value) => {
-        setData(value);
-      })
-      .catch(() => {
->>>>>>> ebb054c ([F] SummitData provider)
         setError(true);
       })
       .finally(() => {
@@ -90,7 +71,6 @@ export const SummitDataProvider = ({ children }) => {
 
   const value = useMemo(
     () => ({
-<<<<<<< HEAD
       currentData,
       hourlyData,
       dailyData,
@@ -98,13 +78,6 @@ export const SummitDataProvider = ({ children }) => {
       error,
     }),
     [currentData, hourlyData, dailyData, loading, error]
-=======
-      data,
-      loading,
-      error,
-    }),
-    [data, loading, error]
->>>>>>> ebb054c ([F] SummitData provider)
   );
 
   return (
@@ -114,9 +87,6 @@ export const SummitDataProvider = ({ children }) => {
   );
 };
 
-<<<<<<< HEAD
 SummitDataProvider.propTypes = { children: PropTypes.node };
 
-=======
->>>>>>> ebb054c ([F] SummitData provider)
 export const useSummitData = () => useContext(SummitDataContext);

--- a/contexts/WeatherUnit.js
+++ b/contexts/WeatherUnit.js
@@ -1,14 +1,60 @@
-import { createContext, useContext } from "react";
+import { createContext, useContext, useReducer } from "react";
+import { useTranslation } from "react-i18next";
+
+export const defaultTempUnit = "celsius";
+export const defaultWindspeedUnit = "m";
 
 export const defaultUnits = {
-  tempUnit: "C",
-  windspeedUnit: "m",
+  tempUnit: defaultTempUnit,
+  windspeedUnit: defaultWindspeedUnit,
 };
 
-const WeatherUnitContext = createContext(defaultUnits);
+const WeatherUnitContext = createContext();
+
+const unitReducer = (state, action) => {
+  console.log(state, action);
+  const { type } = action;
+
+  switch (type) {
+    case "fahrenheit":
+      return { ...state, tempUnit: "fahrenheit" };
+    case "celsius":
+      return { ...state, tempUnit: "celsius" };
+    case "NM":
+      return { ...state, windspeedUnit: "NM" };
+    case "mi":
+      return { ...state, windspeedUnit: "mi" };
+    case "m":
+      return { ...state, windspeedUnit: "m" };
+    default:
+      throw new Error(`Unhandled action type: ${type}`);
+  }
+};
+
+export const WeatherUnitProvider = ({ children }) => {
+  const {
+    i18n: { language = "en" },
+  } = useTranslation();
+  const [state, dispatch] = useReducer(unitReducer, {
+    tempUnit: language === "en" ? "fahrenheit" : defaultUnits.tempUnit,
+    windspeedUnit: language === "en" ? "NM" : defaultUnits.windspeedUnit,
+  });
+
+  return (
+    <WeatherUnitContext.Provider value={[state, dispatch]}>
+      {children}
+    </WeatherUnitContext.Provider>
+  );
+};
 
 export function useWeatherUnit() {
-  return useContext(WeatherUnitContext);
+  const context = useContext(WeatherUnitContext);
+
+  if (context === undefined) {
+    throw new Error("useWeatherUnit must be used within a WeatherUnitProvider");
+  }
+
+  return context;
 }
 
 export default WeatherUnitContext;

--- a/contexts/WeatherUnit.js
+++ b/contexts/WeatherUnit.js
@@ -1,4 +1,5 @@
 import { createContext, useContext, useReducer } from "react";
+import PropTypes from "prop-types";
 import { useTranslation } from "react-i18next";
 
 export const defaultTempUnit = "celsius";
@@ -12,7 +13,6 @@ export const defaultUnits = {
 const WeatherUnitContext = createContext();
 
 const unitReducer = (state, action) => {
-  console.log(state, action);
   const { type } = action;
 
   switch (type) {
@@ -45,6 +45,10 @@ export const WeatherUnitProvider = ({ children }) => {
       {children}
     </WeatherUnitContext.Provider>
   );
+};
+
+WeatherUnitProvider.propTypes = {
+  children: PropTypes.node,
 };
 
 export function useWeatherUnit() {

--- a/contexts/WeatherUnit.js
+++ b/contexts/WeatherUnit.js
@@ -5,11 +5,6 @@ import { useTranslation } from "react-i18next";
 export const defaultTempUnit = "celsius";
 export const defaultWindspeedUnit = "m";
 
-export const defaultUnits = {
-  tempUnit: defaultTempUnit,
-  windspeedUnit: defaultWindspeedUnit,
-};
-
 const WeatherUnitContext = createContext();
 
 const unitReducer = (state, action) => {
@@ -36,8 +31,8 @@ export const WeatherUnitProvider = ({ children }) => {
     i18n: { language = "en" },
   } = useTranslation();
   const [state, dispatch] = useReducer(unitReducer, {
-    tempUnit: language === "en" ? "fahrenheit" : defaultUnits.tempUnit,
-    windspeedUnit: language === "en" ? "NM" : defaultUnits.windspeedUnit,
+    tempUnit: language === "en" ? "fahrenheit" : defaultTempUnit,
+    windspeedUnit: language === "en" ? "NM" : defaultWindspeedUnit,
   });
 
   return (

--- a/helpers/converters.js
+++ b/helpers/converters.js
@@ -1,0 +1,11 @@
+import convert from "convert";
+import { defaultTempUnit, defaultWindspeedUnit } from "@/contexts/WeatherUnit";
+
+export const convertTemperature = (value, toUnit = defaultTempUnit) =>
+  convert(value, defaultTempUnit).to(toUnit);
+
+export const convertWindspeed = (value, toUnit = defaultWindspeedUnit) => {
+  const adjustedValue = toUnit !== "m" ? value * 60 * 60 : value;
+
+  return convert(adjustedValue, defaultWindspeedUnit).to(toUnit);
+};

--- a/helpers/formatters.js
+++ b/helpers/formatters.js
@@ -1,3 +1,5 @@
+const observatoryTZ = "America/Santiago";
+
 export const formatTemperature = (value, locale = "en", unit = "celsius") => {
   const formatter = new Intl.NumberFormat(locale, {
     style: "unit",
@@ -31,8 +33,9 @@ export const formatPercent = (value, locale = "en") => {
   return parts.join("");
 };
 
-export const formatTime = (value, locale = "en") => {
+export const formatTime = (value, locale = "en", observatoryTime = "true") => {
   return new Intl.DateTimeFormat(locale, {
     timeStyle: "short",
+    ...(observatoryTime && { timeZone: observatoryTZ }),
   }).format(value);
 };

--- a/lib/api/queries/weather.js
+++ b/lib/api/queries/weather.js
@@ -9,7 +9,7 @@ export const currentWeather = (bucket) => flux`from(bucket: "${bucket}")
   |> group()
   |> pivot(rowKey:["_pivoter"], columnKey: ["_field"], valueColumn: "_value")
   |> drop(columns: ["_pivoter"])
-  |> rename(columns: {direction: "windDirection", speed: "windSpeed"})
+  |> rename(columns: {direction: "windDirection", speed: "windspeed"})
   |> yield(name: "realtime")`;
 
 export const hourlyWeather = (bucket) => {
@@ -44,23 +44,19 @@ export const dailyWeather = (bucket) => {
   date.setHours(0, 0, 0, 0);
   return flux`data = from(bucket: "${bucket}")
       |> range(start: ${date}, stop: now())
-      |> filter(fn: (r) => r["_measurement"] == "lsst.sal.ESS.pressure" or r["_measurement"] == "lsst.sal.ESS.dewPoint" or r["_measurement"] == "lsst.sal.ESS.temperature" or r["_measurement"] == "lsst.sal.ESS.relativeHumidity" or r["_measurement"] == "lsst.sal.ESS.airFlow")
-      |> filter(fn: (r) => r["_field"] == "relativeHumidity" or r["_field"] == "dewPoint" or r["_field"] == "temperature0" or r["_field"] == "speed" or r["_field"] == "pressure0" or r["_field"] == "direction")
+      |> filter(fn: (r) => r["_measurement"] == "lsst.sal.ESS.temperature")
+      |> filter(fn: (r) => r["_field"] == "temperature0")
       |> drop(columns: ["_measurement"])
       
   min = data
       |> aggregateWindow(every: 1d, fn: min, createEmpty: true)
       |> map(fn: (r) => ({r with _field: r._field + "_min"}))
-        
-  mean = data
-      |> aggregateWindow(every: 1d, fn: mean, createEmpty: true)
-      |> map(fn: (r) => ({r with _field: r._field + "_mean"}))
   
   max = data
       |> aggregateWindow(every: 1d, fn: max, createEmpty: true)
       |> map(fn: (r) => ({r with _field: r._field + "_max"}))
       
-  union(tables: [min, mean, max])
+  union(tables: [min, max])
       |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
       |> sort(columns: ["_time"])
       |> yield(name: "historical")`;

--- a/lib/api/queries/weather.js
+++ b/lib/api/queries/weather.js
@@ -39,11 +39,21 @@ union(tables: [min, mean, max])
 };
 
 export const dailyWeather = (bucket) => {
-  const date = new Date();
-  date.setDate(date.getDate() - 7);
-  date.setHours(0, 0, 0, 0);
+  const start = new Date();
+  const end = new Date();
+
+  start.setUTCDate(start.getUTCDate() - 7);
+  start.setUTCHours(0, 0, 0, 0);
+  const observatoryDate = new Date(
+    start.toLocaleString("en-US", { timeZone: "America/Santiago" })
+  );
+  const diff = 24 - observatoryDate.getHours();
+
+  start.setUTCHours(diff, 0, 0, 0);
+  end.setUTCHours(diff, 0, 0, 0);
+
   return flux`data = from(bucket: "${bucket}")
-      |> range(start: ${date}, stop: now())
+      |> range(start: ${start}, stop: ${end})
       |> filter(fn: (r) => r["_measurement"] == "lsst.sal.ESS.temperature")
       |> filter(fn: (r) => r["_field"] == "temperature0")
       |> drop(columns: ["_measurement"])

--- a/lib/localeStrings/en.json
+++ b/lib/localeStrings/en.json
@@ -346,9 +346,12 @@
         "m_full": "Meters per second"
       },
       "sections": {
-        "current": "Weather at the summit now",
-        "hourly": "Hourly weather stats",
-        "daily": "Daily temperature variations - {{unit}} degrees (last week)"
+        "weather": {
+          "preview": "Weather at the summit",
+          "current": "Weather at the summit now",
+          "hourly": "Hourly weather stats",
+          "daily": "Daily temperature variations - {{unit}} degrees (last week)"
+        }
       },
       "weather": {
         "temp_daily_max": "High",

--- a/lib/localeStrings/en.json
+++ b/lib/localeStrings/en.json
@@ -345,6 +345,11 @@
         "mi_full": "Miles per hour",
         "m_full": "Meters per second"
       },
+      "sections": {
+        "current": "Weather at the summit now",
+        "hourly": "Hourly weather stats",
+        "daily": "Daily temperature variations - {{unit}} degrees (last week)"
+      },
       "weather": {
         "temp_daily_max": "High",
         "temp_daily_min": "Low",


### PR DESCRIPTION
This adds the modal that will contain all "detail" sections on the summit dashboard along with an implementation of the weather widgets.

There is one other major change included here, the weather unit provider has been refactored so that the unit localization selector does not need to have props and callbacks passed up and down through the individual sections and their modals. I have also trimmed down the data queries for the weather data to improve load times. 