### PR TITLE
[EPO-8239] EFD secrets are secret

### DIFF
--- a/contexts/SummitData.js
+++ b/contexts/SummitData.js
@@ -1,112 +1,53 @@
 import {
   createContext,
   useContext,
-  useEffect,
   useMemo,
-  useState,
-  useReducer,
 } from "react";
-import {
-  currentWeather,
-  dailyWeather,
-  hourlyWeather,
-} from "@/lib/api/queries/weather";
 import PropTypes from "prop-types";
-import queryEfd from "@/lib/api/efd";
+import useEfd from "@/lib/api/efd";
 
 export const SummitDataContext = createContext({});
 
-const loadingReducer = (state, action) => {
-  const { type, dataSet } = action;
-
-  switch (type) {
-    case "complete":
-      return { ...state, [dataSet]: false };
-    case "loading":
-      return { ...state, [dataSet]: true };
-    default:
-      throw new Error(`Unhandled action type: ${type}`);
-  }
-};
-
-const defaultLoadState = {
-  currentData: true,
-  hourlyData: true,
-  dailyData: true,
-};
-
 export const SummitDataProvider = ({ children }) => {
-  const [currentData, setCurrentData] = useState();
-  const [hourlyData, setHourlyData] = useState();
-  const [dailyData, setDailyData] = useState();
-  const [error, setError] = useState(false);
-  const [loading, dispatch] = useReducer(loadingReducer, defaultLoadState);
-
-  const fetchCurrentWeather = () =>
-    new Promise((resolve, reject) => {
-      queryEfd(currentWeather)
-        .then((value) => {
-          setCurrentData(...value);
-          resolve(...value);
-        })
-        .catch((e) => {
-          reject(e);
-        })
-        .finally(() => {
-          dispatch({ type: "complete", dataSet: "currentData" });
-        });
-    });
-
-  const fetchHourlyWeather = () =>
-    new Promise((resolve, reject) => {
-      queryEfd(hourlyWeather)
-        .then((value) => {
-          setHourlyData(value);
-          resolve(value);
-        })
-        .catch((e) => {
-          reject(e);
-        })
-        .finally(() => {
-          dispatch({ type: "complete", dataSet: "hourlyData" });
-        });
-    });
-
-  const fetchDailyWeather = () =>
-    new Promise((resolve, reject) => {
-      queryEfd(dailyWeather)
-        .then((value) => {
-          setDailyData(value);
-          resolve(value);
-        })
-        .catch((e) => {
-          reject(e);
-        })
-        .finally(() => {
-          dispatch({ type: "complete", dataSet: "dailyData" });
-        });
-    });
-
-  useEffect(() => {
-    Promise.allSettled([
-      fetchCurrentWeather(),
-      fetchHourlyWeather(),
-      fetchDailyWeather(),
-    ]).catch((e) => {
-      console.error(e);
-      setError(true);
-    });
-  }, []);
+  const {
+    data: currentData,
+    isLoading: currentIsLoading,
+    isError: currentIsError,
+  } = useEfd("current");
+  const {
+    data: hourlyData,
+    isLoading: hourlyIsLoading,
+    isError: hourlyIsError,
+  } = useEfd("hourly");
+  const {
+    data: dailyData,
+    isLoading: dailyIsLoading,
+    isError: dailyIsError,
+  } = useEfd("daily");
 
   const value = useMemo(
     () => ({
       currentData,
       hourlyData,
       dailyData,
-      loading,
-      error,
+      error: currentIsError || hourlyIsError || dailyIsError,
+      loading: {
+        currentData: currentIsLoading,
+        hourlyData: hourlyIsLoading,
+        dailyData: dailyIsLoading,
+      },
     }),
-    [currentData, hourlyData, dailyData, loading, error]
+    [
+      currentData,
+      hourlyData,
+      dailyData,
+      currentIsLoading,
+      hourlyIsLoading,
+      dailyIsLoading,
+      currentIsError,
+      hourlyIsError,
+      dailyIsError,
+    ]
   );
 
   return (

--- a/lib/api/efd.js
+++ b/lib/api/efd.js
@@ -2,7 +2,7 @@ import useSWR from "swr";
 
 const fetcher = (url) => fetch(url).then((res) => res.json());
 
-export default async function useEfd(type) {
+export default function useEfd(type) {
   const { data, error } = useSWR(`/api/efd/${type}`, fetcher);
 
   return {

--- a/lib/api/efd.js
+++ b/lib/api/efd.js
@@ -1,25 +1,13 @@
-import { InfluxDB } from "@influxdata/influxdb-client";
+import useSWR from "swr";
 
-export default function queryEfd(query) {
-  const url = process.env.NEXT_PUBLIC_EFD_URL;
-  const bucket = process.env.NEXT_PUBLIC_EFD_BUCKET;
-  const token = process.env.NEXT_PUBLIC_EFD_TOKEN;
+const fetcher = (url) => fetch(url).then((res) => res.json());
 
-  const influxDB = new InfluxDB({ url, token });
-  const queryApi = influxDB.getQueryApi("");
+export default async function useEfd(type) {
+  const { data, error } = useSWR(`/api/efd/${type}`, fetcher);
 
-  return new Promise((resolve, reject) => {
-    const data = [];
-    queryApi.queryRows(query(bucket), {
-      next(row, tableMeta) {
-        data.push(tableMeta.toObject(row));
-      },
-      error(error) {
-        reject(error);
-      },
-      complete() {
-        resolve(data);
-      },
-    });
-  });
+  return {
+    data,
+    isLoading: !error && !data,
+    isError: error,
+  };
 }

--- a/pages/api/efd/[type].js
+++ b/pages/api/efd/[type].js
@@ -6,7 +6,7 @@ import {
 } from "@/lib/api/queries/weather";
 
 const types = {
-	current: currentWeather,
+  current: currentWeather,
   hourly: hourlyWeather,
   daily: dailyWeather,
 };
@@ -29,12 +29,10 @@ export default function handler(req, res) {
       data.push(tableMeta.toObject(row));
     },
     error(error) {
-      // reject(error);
-      res.status(200).json({ error })
+      return res.status(405).json(error);
     },
     complete() {
-      // resolve(data);
-      res.status(200).json({ data })
+      return res.status(200).json(type === "current" ? data[0] : data);
     },
   });
 }

--- a/pages/api/efd/[type].js
+++ b/pages/api/efd/[type].js
@@ -1,0 +1,40 @@
+import { InfluxDB } from "@influxdata/influxdb-client";
+import {
+  currentWeather,
+  dailyWeather,
+  hourlyWeather,
+} from "@/lib/api/queries/weather";
+
+const types = {
+	current: currentWeather,
+  hourly: hourlyWeather,
+  daily: dailyWeather,
+};
+
+export default function handler(req, res) {
+  const url = process.env.EFD_URL;
+  const bucket = process.env.EFD_BUCKET;
+  const token = process.env.EFD_TOKEN;
+
+  const influxDB = new InfluxDB({ url, token });
+  const queryApi = influxDB.getQueryApi("");
+
+  const { type } = req.query;
+  const query = types[type];
+
+  const data = [];
+
+  queryApi.queryRows(query(bucket), {
+    next(row, tableMeta) {
+      data.push(tableMeta.toObject(row));
+    },
+    error(error) {
+      // reject(error);
+      res.status(200).json({ error })
+    },
+    complete() {
+      // resolve(data);
+      res.status(200).json({ data })
+    },
+  });
+}


### PR DESCRIPTION
A bit of an add on and resulting refactor.  As of writing this comment, the USDF is down for scheduled maintainence, so a little tricky to 100% know this is all working, but suffice to say the goals of this change were thus:
- move the use of the EFD credentials serverside so they're not exposed to the browser/clever users

And then, while I was in there, [based on some of the examples of this kind of thing I was seeing](https://www.smashingmagazine.com/2021/12/protect-api-key-production-nextjs-api-route/) it seemed like I could also incorporate SWR, and that it would do some/all of the statey promisey stuff for us?  But that's both the part that's hard for me to understand without actually being able to reach the USDF EFD, and also the part I am the least knowledgable in. I very well may have taken this part too far and dissolved some of the custom statey promisey stuff you had and that other components were very much depending on.  So take a look and let me know what you think.

