### PR TITLE
[C] fix daytime showing incorrectly between 12-1pm

### DIFF
--- a/components/dynamic/SummitData/Astroweather/index.js
+++ b/components/dynamic/SummitData/Astroweather/index.js
@@ -23,7 +23,7 @@ const Astroweather = () => {
   tomorrow.setDate(tomorrow.getDate() + 1);
   yesterday.setDate(yesterday.getDate() - 1);
 
-  const isAfterNoon = today.getUTCHours() - offset > 12;
+  const isAfterNoon = today.getUTCHours() - offset >= 12;
   const dates = isAfterNoon ? [today, tomorrow] : [yesterday, today];
 
   const { phase } = getMoonIllumination(today);


### PR DESCRIPTION
There was a bug where times between 12pm and 1pm would not meet the "isAfterNoon" conditions and then the current time tick would appear off the edge of the widget. This changes the evaluation to greater or equal to 12 hours so anything after 11:59:59am is "after noon"