### PR TITLE
[C] move astroweather calcs to endpoint

### DIFF
--- a/components/dynamic/SummitData/Astroweather/Current/index.js
+++ b/components/dynamic/SummitData/Astroweather/Current/index.js
@@ -1,12 +1,10 @@
-import PropTypes from "prop-types";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useSummitData } from "@/contexts/SummitData";
 import WidgetSection from "@/components/layout/WidgetSection";
-import Daylight, {
-  DaylightDataShape,
-} from "@/components/widgets/CurrentData/patterns/Daylight";
+import Daylight from "@/components/widgets/CurrentData/patterns/Daylight";
 
-const CurrentAstroweather = ({ data }) => {
+const CurrentAstroweather = () => {
   const { t } = useTranslation();
   const [isOpen, setOpen] = useState(true);
   const sectionProps = {
@@ -14,22 +12,24 @@ const CurrentAstroweather = ({ data }) => {
     onToggleCallback: (value) => setOpen(value),
     isOpen,
   };
+  const {
+    astroweatherData,
+    loading: { astroweatherData: loading },
+  } = useSummitData();
 
-  const { daylight } = data;
+  if (loading) {
+    return null;
+  }
+
+  const { solarTimes: times } = astroweatherData;
 
   return (
     <WidgetSection {...sectionProps}>
-      <Daylight {...daylight} variant="secondary" />
+      <Daylight times={times} variant="secondary" />
     </WidgetSection>
   );
 };
 
 CurrentAstroweather.displayName = "Dynamic.Astroweather.Current";
-
-CurrentAstroweather.propTypes = {
-  data: PropTypes.shape({
-    daylight: PropTypes.shape(DaylightDataShape),
-  }),
-};
 
 export default CurrentAstroweather;

--- a/components/dynamic/SummitData/Astroweather/Current/index.js
+++ b/components/dynamic/SummitData/Astroweather/Current/index.js
@@ -12,12 +12,9 @@ const CurrentAstroweather = () => {
     onToggleCallback: (value) => setOpen(value),
     isOpen,
   };
-  const {
-    astroweatherData,
-    loading: { astroweatherData: loading },
-  } = useSummitData();
+  const { astroweatherData, isLoading } = useSummitData();
 
-  if (loading) {
+  if (isLoading.astroweather || !astroweatherData) {
     return null;
   }
 

--- a/components/dynamic/SummitData/Astroweather/Forecast/index.js
+++ b/components/dynamic/SummitData/Astroweather/Forecast/index.js
@@ -39,44 +39,26 @@ const ForecastAstroweather = () => {
       </WidgetSection>
     );
 
+  // const { lunarPhase: phase, lunarTimes: times } = astroweatherData;
+
   const moonriseId = "moonriseTitle";
   const now = new Date();
-
-  const { phase } = getMoonIllumination(now);
-
-  const conversion = 180 / Math.PI;
-  const getAzimuth = (time) =>
-    getMoonPosition(time, lat, long).azimuth * conversion + 180;
-
-  const forecast = Array.apply(null, Array(14)).map((value, i) => {
-    const day = new Date();
-    day.setDate(now.getDate() + i);
-    const { rise, set } = getMoonTimes(day, lat, long);
-
-    return {
-      day: day.getDay(),
-      rise,
-      set,
-      azimuthRise: rise ? getAzimuth(rise) : null,
-      azimuthSet: set ? getAzimuth(set) : null,
-    };
-  });
 
   const { dewPoint } = current;
   const dewpoint = convertTemperature(dewPoint, tempUnit);
 
   return (
     <WidgetSection {...sectionProps}>
-      <MoonPhase phase={phase} />
+      {/* <MoonPhase phase={phase} />
       <MoonRise
-        rise={forecast[0].rise < now ? forecast[1].rise : forecast[0].rise}
-        set={forecast[0].set < now ? forecast[1].set : forecast[0].set}
-      />
+        rise={times[0].rise < now ? times[1].rise : times[0].rise}
+        set={times[0].set < now ? times[1].set : times[0].set}
+      /> */}
       <DewpointCurrent dewpoint={dewpoint} unit={tempUnit} />
       <SectionSubHeader id={moonriseId}>
         {t("summit_dashboard.sections.astro.moonrise.forecast")}
       </SectionSubHeader>
-      <DailyMoonrise data={forecast} labelledById={moonriseId} />
+      {/* <DailyMoonrise data={times} labelledById={moonriseId} /> */}
     </WidgetSection>
   );
 };

--- a/components/dynamic/SummitData/Astroweather/Forecast/index.js
+++ b/components/dynamic/SummitData/Astroweather/Forecast/index.js
@@ -3,12 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useWeatherUnit } from "@/contexts/WeatherUnit";
 import { useSummitData } from "@/contexts/SummitData";
 import { convertTemperature } from "@/helpers/converters";
-import {
-  getMoonIllumination,
-  getMoonPosition,
-  getMoonTimes,
-} from "@/lib/suncalc";
-import { lat, long } from "@/lib/observatory";
+
 import WidgetSection from "@/components/layout/WidgetSection";
 import MoonRise from "@/components/widgets/CurrentData/patterns/MoonRise";
 import MoonPhase from "@/components/widgets/CurrentData/patterns/MoonPhase";
@@ -23,6 +18,7 @@ const ForecastAstroweather = () => {
   const [{ tempUnit }] = useWeatherUnit();
   const {
     data: { current },
+    astroweatherData,
     isLoading,
   } = useSummitData();
 
@@ -32,14 +28,14 @@ const ForecastAstroweather = () => {
     isOpen,
   };
 
-  if (isLoading || !current)
+  if (isLoading.astroweather || isLoading.efd || !current || !astroweatherData)
     return (
       <WidgetSection {...sectionProps}>
         <Loader isVisible={true} />
       </WidgetSection>
     );
 
-  // const { lunarPhase: phase, lunarTimes: times } = astroweatherData;
+  const { lunarPhase: phase, lunarTimes: times } = astroweatherData;
 
   const moonriseId = "moonriseTitle";
   const now = new Date();
@@ -49,16 +45,16 @@ const ForecastAstroweather = () => {
 
   return (
     <WidgetSection {...sectionProps}>
-      {/* <MoonPhase phase={phase} />
+      <MoonPhase phase={phase} />
       <MoonRise
         rise={times[0].rise < now ? times[1].rise : times[0].rise}
         set={times[0].set < now ? times[1].set : times[0].set}
-      /> */}
+      />
       <DewpointCurrent dewpoint={dewpoint} unit={tempUnit} />
       <SectionSubHeader id={moonriseId}>
         {t("summit_dashboard.sections.astro.moonrise.forecast")}
       </SectionSubHeader>
-      {/* <DailyMoonrise data={times} labelledById={moonriseId} /> */}
+      <DailyMoonrise data={times} labelledById={moonriseId} />
     </WidgetSection>
   );
 };

--- a/components/dynamic/SummitData/Astroweather/index.js
+++ b/components/dynamic/SummitData/Astroweather/index.js
@@ -10,13 +10,10 @@ import ForecastAstroweather from "./Forecast";
 
 const Astroweather = () => {
   const { t } = useTranslation();
-  const {
-    astroweatherData,
-    loading: { astroweatherData: loading },
-  } = useSummitData();
+  const { astroweatherData, isLoading } = useSummitData();
   const [isModalOpen, setModalOpen] = useState(false);
 
-  if (loading) {
+  if (isLoading.astroweather || !astroweatherData) {
     return null;
   }
 

--- a/components/dynamic/SummitData/Astroweather/index.js
+++ b/components/dynamic/SummitData/Astroweather/index.js
@@ -1,39 +1,26 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { getMoonIllumination, getTimes } from "@/lib/suncalc";
+import { useSummitData } from "@/contexts/SummitData";
 import WidgetPreview from "@/components/layout/WidgetPreview";
 import SummitStatusModal from "@/components/modal/SummitStatusModal";
 import MoonPhase from "@/components/widgets/CurrentData/patterns/MoonPhase";
 import Daylight from "@/components/widgets/CurrentData/patterns/Daylight";
-import { altitude, lat, long, timezone } from "@/lib/observatory";
-import { timezoneOffset, timezoneOffsetLocal } from "@/helpers";
 import CurrentAstroweather from "./Current";
 import ForecastAstroweather from "./Forecast";
 
 const Astroweather = () => {
   const { t } = useTranslation();
+  const {
+    astroweatherData,
+    loading: { astroweatherData: loading },
+  } = useSummitData();
   const [isModalOpen, setModalOpen] = useState(false);
 
-  const offset = timezoneOffset(timezone);
-  const localOffset = timezoneOffsetLocal(timezone);
+  if (loading) {
+    return null;
+  }
 
-  const today = new Date();
-  const tomorrow = new Date(today);
-  const yesterday = new Date(today);
-  tomorrow.setDate(tomorrow.getDate() + 1);
-  yesterday.setDate(yesterday.getDate() - 1);
-
-  const isAfterNoon = today.getUTCHours() - offset >= 12;
-  const dates = isAfterNoon ? [today, tomorrow] : [yesterday, today];
-
-  const { phase } = getMoonIllumination(today);
-  const { sunset, night } = getTimes(dates[0], lat, long, altitude);
-  const { nightEnd: dawn, sunrise } = getTimes(dates[1], lat, long, altitude);
-
-  const times = { dawn, sunrise, sunset, night };
-  Object.keys(times).forEach((key) => {
-    times[key].setHours(times[key].getHours() - localOffset);
-  });
+  const { lunarPhase: phase, solarTimes: times } = astroweatherData;
 
   return (
     <WidgetPreview
@@ -44,10 +31,10 @@ const Astroweather = () => {
       }}
     >
       <MoonPhase phase={phase} />
-      <Daylight {...{ ...times, dates }} />
+      <Daylight times={times} />
       <SummitStatusModal open={isModalOpen} onClose={() => setModalOpen(false)}>
         <ForecastAstroweather />
-        <CurrentAstroweather data={{ daylight: { ...times, dates } }} />
+        <CurrentAstroweather />
       </SummitStatusModal>
     </WidgetPreview>
   );

--- a/components/dynamic/SummitData/Observation/Related/index.js
+++ b/components/dynamic/SummitData/Observation/Related/index.js
@@ -6,6 +6,7 @@ import { convertTemperature } from "@/helpers/converters";
 import Loader from "@/components/atomic/Loader";
 import WidgetSection from "@/components/layout/WidgetSection";
 import DewpointCurrent from "@/components/widgets/CurrentData/patterns/Dewpoint";
+import MoonPhase from "@/components/widgets/CurrentData/patterns/MoonPhase";
 
 const Related = () => {
   const { t } = useTranslation();
@@ -13,6 +14,7 @@ const Related = () => {
   const [{ tempUnit }] = useWeatherUnit();
   const {
     data: { current },
+    astroweatherData,
     isLoading,
   } = useSummitData();
 
@@ -22,18 +24,20 @@ const Related = () => {
     isOpen,
   };
 
-  if (isLoading || !current)
+  if (isLoading.efd || isLoading.astroweather || !astroweatherData || !current)
     return (
       <WidgetSection {...sectionProps}>
         <Loader isVisible={true} />
       </WidgetSection>
     );
 
+  const { lunarPhase } = astroweatherData;
   const { dewPoint } = current;
   const dewpoint = convertTemperature(dewPoint, tempUnit);
 
   return (
     <WidgetSection {...sectionProps}>
+      <MoonPhase phase={lunarPhase} />
       <DewpointCurrent dewpoint={dewpoint} unit={tempUnit} />
     </WidgetSection>
   );

--- a/components/dynamic/SummitData/Weather/Current/index.js
+++ b/components/dynamic/SummitData/Weather/Current/index.js
@@ -23,7 +23,7 @@ const CurrentWeather = () => {
     isOpen,
   };
 
-  if (isLoading || !current)
+  if (isLoading.efd || !current)
     return (
       <WidgetSection {...sectionProps}>
         <Loader isVisible={true} />

--- a/components/dynamic/SummitData/Weather/Daily/index.js
+++ b/components/dynamic/SummitData/Weather/Daily/index.js
@@ -23,7 +23,7 @@ const DailyWeather = () => {
     isOpen,
   };
 
-  if (isLoading || !daily)
+  if (isLoading.efd || !daily)
     return (
       <WidgetSection {...sectionProps}>
         <Loader isVisible={true} />

--- a/components/dynamic/SummitData/Weather/Hourly/index.js
+++ b/components/dynamic/SummitData/Weather/Hourly/index.js
@@ -21,7 +21,7 @@ const HourlyWeather = () => {
     isOpen,
   };
 
-  if (isLoading || !hourly)
+  if (isLoading.efd || !hourly)
     return (
       <WidgetSection {...sectionProps}>
         <Loader isVisible={true} />

--- a/components/dynamic/SummitData/Weather/index.js
+++ b/components/dynamic/SummitData/Weather/index.js
@@ -25,7 +25,7 @@ const Weather = () => {
     title: t("summit_dashboard.sections.weather.preview"),
   };
 
-  if (isLoading || !current)
+  if (isLoading.efd || !current)
     return (
       <WidgetPreview {...previewProps}>
         <Loader isVisible={true} />

--- a/components/widgets/CurrentData/patterns/Daylight/index.js
+++ b/components/widgets/CurrentData/patterns/Daylight/index.js
@@ -9,7 +9,7 @@ import { timezone } from "@/lib/observatory";
 import { useTranslation } from "react-i18next";
 import ChartLegend from "@/components/charts/Legend";
 
-const Daylight = ({ times, variant = "primary" }) => {
+const Daylight = ({ times = [], variant = "primary" }) => {
   const {
     t,
     i18n: { language = "en-US" },

--- a/components/widgets/CurrentData/patterns/MoonRise/index.js
+++ b/components/widgets/CurrentData/patterns/MoonRise/index.js
@@ -23,26 +23,29 @@ const MoonRise = ({ rise, set }) => {
       language
     );
 
+  const riseDate = new Date(rise);
+  const setDate = new Date(set);
+
   return (
     <Styled.Background $variant="secondary">
       <Styled.Timecard>
         <Styled.Label>
           {t("summit_dashboard.sections.astro.moonrise.time_moonrise")}
         </Styled.Label>
-        <Styled.Time as="time" dateTime={rise.toISOString()}>
-          {formatTime(rise, language, { hourCycle: "h24" })}
+        <Styled.Time as="time" dateTime={riseDate.toISOString()}>
+          {formatTime(riseDate, language, { hourCycle: "h24" })}
         </Styled.Time>
-        <Styled.Unit>{getRelativeTime(rise, now)}</Styled.Unit>
+        <Styled.Unit>{getRelativeTime(riseDate, now)}</Styled.Unit>
       </Styled.Timecard>
       <Styled.Divider role="presentation" />
       <Styled.Timecard>
         <Styled.Label>
           {t("summit_dashboard.sections.astro.moonrise.time_moonset")}
         </Styled.Label>
-        <Styled.Time as="time" dateTime={set.toISOString()}>
-          {formatTime(set, language, { hourCycle: "h24" })}
+        <Styled.Time as="time" dateTime={setDate.toISOString()}>
+          {formatTime(setDate, language, { hourCycle: "h24" })}
         </Styled.Time>
-        <Styled.Unit>{getRelativeTime(set, now)}</Styled.Unit>
+        <Styled.Unit>{getRelativeTime(setDate, now)}</Styled.Unit>
       </Styled.Timecard>
     </Styled.Background>
   );
@@ -51,8 +54,16 @@ const MoonRise = ({ rise, set }) => {
 MoonRise.displayName = "Widgets.Current.MoonRise";
 
 MoonRise.propTypes = {
-  rise: PropTypes.instanceOf(Date),
-  set: PropTypes.instanceOf(Date),
+  rise: PropTypes.oneOfType([
+    PropTypes.instanceOf(Date),
+    PropTypes.string,
+    PropTypes.number,
+  ]),
+  set: PropTypes.oneOfType([
+    PropTypes.instanceOf(Date),
+    PropTypes.string,
+    PropTypes.number,
+  ]),
 };
 
 export default MoonRise;

--- a/components/widgets/DailyData/patterns/Moonrise/Time/index.js
+++ b/components/widgets/DailyData/patterns/Moonrise/Time/index.js
@@ -6,7 +6,9 @@ import * as Styled from "./styles";
 const MoonTime = ({ time, azimuth }) => {
   return (
     <Styled.Container>
-      <time dateTime={time.toISOString()}>{formatTime(time)}</time>
+      <time dateTime={new Date(time).toISOString()}>
+        {formatTime(new Date(time))}
+      </time>
       <DirectionalArrow angle={azimuth} />({formatAngle(azimuth)})
     </Styled.Container>
   );
@@ -15,7 +17,11 @@ const MoonTime = ({ time, azimuth }) => {
 MoonTime.displayName = "Widgets.Daily.MoonTime";
 
 MoonTime.propTypes = {
-  time: PropTypes.instanceOf(Date),
+  time: PropTypes.oneOfType([
+    PropTypes.instanceOf(Date),
+    PropTypes.string,
+    PropTypes.number,
+  ]),
   azimuth: PropTypes.number,
 };
 

--- a/components/widgets/DailyData/patterns/Moonrise/index.js
+++ b/components/widgets/DailyData/patterns/Moonrise/index.js
@@ -29,9 +29,9 @@ const DailyMoonrise = ({ data, labelledById }) => {
         </tr>
       </thead>
       <tbody>
-        {data.map(({ day, rise, set, azimuthRise, azimuthSet }) => {
+        {data.map(({ day, rise, set, azimuthRise, azimuthSet }, i) => {
           return (
-            <tr key={rise}>
+            <tr key={i}>
               <Styled.HeaderCell scope="row">
                 {formatDayName(day, language)}
               </Styled.HeaderCell>
@@ -64,8 +64,16 @@ DailyMoonrise.propTypes = {
   data: PropTypes.arrayOf(
     PropTypes.shape({
       day: PropTypes.number,
-      rise: PropTypes.instanceOf(Date),
-      set: PropTypes.instanceOf(Date),
+      rise: PropTypes.oneOfType([
+        PropTypes.instanceOf(Date),
+        PropTypes.string,
+        PropTypes.number,
+      ]),
+      set: PropTypes.oneOfType([
+        PropTypes.instanceOf(Date),
+        PropTypes.string,
+        PropTypes.number,
+      ]),
       azimuthRise: PropTypes.number,
       azimuthSet: PropTypes.number,
     })

--- a/contexts/SummitData.js
+++ b/contexts/SummitData.js
@@ -7,51 +7,26 @@ export const SummitDataContext = createContext({});
 
 export const SummitDataProvider = ({ children }) => {
   const {
-    data: astroweatherData,
+    data: astroweatherData = {},
     isLoading: astroweatherIsLoading,
     isError: astroweatherIsError,
   } = useAstroweather();
-  const {
-    data: currentData,
-    isLoading: currentIsLoading,
-    isError: currentIsError,
-  } = useEfd("current");
-  const {
-    data: hourlyData,
-    isLoading: hourlyIsLoading,
-    isError: hourlyIsError,
-  } = useEfd("hourly");
-  const {
-    data: dailyData,
-    isLoading: dailyIsLoading,
-    isError: dailyIsError,
-  } = useEfd("daily");
+  const { data = {}, isLoading, isError } = useEfd();
 
   const value = useMemo(
     () => ({
-      currentData,
-      hourlyData,
-      dailyData,
+      data,
       astroweatherData,
-      error:
-        currentIsError || hourlyIsError || dailyIsError || astroweatherIsError,
-      loading: {
-        currentData: currentIsLoading,
-        hourlyData: hourlyIsLoading,
-        dailyData: dailyIsLoading,
-        astroweatherData: astroweatherIsLoading,
+      error: { efd: isError, astroweather: astroweatherIsError },
+      isLoading: {
+        efd: isLoading,
+        astroweather: astroweatherIsLoading,
       },
     }),
     [
-      currentData,
-      hourlyData,
-      dailyData,
-      currentIsLoading,
-      hourlyIsLoading,
-      dailyIsLoading,
-      currentIsError,
-      hourlyIsError,
-      dailyIsError,
+      data,
+      isLoading,
+      isError,
       astroweatherData,
       astroweatherIsLoading,
       astroweatherIsError,

--- a/contexts/SummitData.js
+++ b/contexts/SummitData.js
@@ -1,19 +1,61 @@
 import { createContext, useContext, useMemo } from "react";
 import PropTypes from "prop-types";
 import useEfd from "@/lib/api/efd";
+import useAstroweather from "@/lib/api/astroweather";
 
 export const SummitDataContext = createContext({});
 
 export const SummitDataProvider = ({ children }) => {
-  const { data = {}, isLoading, error } = useEfd();
+  const {
+    data: astroweatherData,
+    isLoading: astroweatherIsLoading,
+    isError: astroweatherIsError,
+  } = useAstroweather();
+  const {
+    data: currentData,
+    isLoading: currentIsLoading,
+    isError: currentIsError,
+  } = useEfd("current");
+  const {
+    data: hourlyData,
+    isLoading: hourlyIsLoading,
+    isError: hourlyIsError,
+  } = useEfd("hourly");
+  const {
+    data: dailyData,
+    isLoading: dailyIsLoading,
+    isError: dailyIsError,
+  } = useEfd("daily");
 
   const value = useMemo(
     () => ({
-      data,
-      isLoading,
-      error,
+      currentData,
+      hourlyData,
+      dailyData,
+      astroweatherData,
+      error:
+        currentIsError || hourlyIsError || dailyIsError || astroweatherIsError,
+      loading: {
+        currentData: currentIsLoading,
+        hourlyData: hourlyIsLoading,
+        dailyData: dailyIsLoading,
+        astroweatherData: astroweatherIsLoading,
+      },
     }),
-    [data, isLoading, error]
+    [
+      currentData,
+      hourlyData,
+      dailyData,
+      currentIsLoading,
+      hourlyIsLoading,
+      dailyIsLoading,
+      currentIsError,
+      hourlyIsError,
+      dailyIsError,
+      astroweatherData,
+      astroweatherIsLoading,
+      astroweatherIsError,
+    ]
   );
 
   return (

--- a/lib/api/astroweather.js
+++ b/lib/api/astroweather.js
@@ -1,0 +1,15 @@
+import useSWR from "swr";
+
+const fetcher = (url) => fetch(url).then((res) => res.json());
+
+export default function useAstroweather() {
+  const { data, error } = useSWR(`/api/astroweather`, fetcher, {
+    refreshInterval: 60000,
+  });
+
+  return {
+    data,
+    isLoading: !error && !data,
+    isError: error,
+  };
+}

--- a/lib/api/efd.js
+++ b/lib/api/efd.js
@@ -11,11 +11,11 @@ const fetcher = (url) =>
 export default function useEfd() {
   const url = process.env.NEXT_PUBLIC_EFD_URL;
 
-  const { data, error, isLoading } = useSWR(url, fetcher);
+  const { data, error } = useSWR(url, fetcher);
 
   return {
     data,
-    isLoading,
+    isLoading: !error && !data,
     error,
   };
 }

--- a/lib/suncalc.js
+++ b/lib/suncalc.js
@@ -263,7 +263,7 @@ export function getMoonPosition(date, lat, lng) {
 // Chapter 48 of "Astronomical Algorithms" 2nd edition by Jean Meeus (Willmann-Bell, Richmond) 1998.
 
 export function getMoonIllumination(date) {
-  const d = toDays(date || new Date()(Date.now()));
+  const d = toDays(date || new Date(Date.now()));
   const s = sunCoords(d);
   const m = moonCoords(d);
   const sdist = 149598000; // distance from Earth to Sun in km

--- a/pages/api/astroweather.js
+++ b/pages/api/astroweather.js
@@ -1,0 +1,70 @@
+import { altitude, lat, long, timezone } from "@/lib/observatory";
+import { timezoneOffset, timezoneOffsetLocal } from "@/helpers";
+import {
+  getMoonIllumination,
+  getMoonPosition,
+  getMoonTimes,
+  getTimes,
+} from "@/lib/suncalc";
+
+const conversion = 180 / Math.PI;
+
+const getAzimuth = (time) =>
+  getMoonPosition(time, lat, long).azimuth * conversion + 180;
+
+const getLunarTimes = () => {
+  const now = new Date();
+
+  return Array.apply(null, Array(14)).map((value, i) => {
+    const day = new Date();
+    day.setDate(now.getDate() + i);
+    const { rise, set } = getMoonTimes(day, lat, long);
+
+    return {
+      day: day.getDay(),
+      rise,
+      set,
+      azimuthRise: rise ? getAzimuth(rise) : null,
+      azimuthSet: set ? getAzimuth(set) : null,
+    };
+  });
+};
+
+const getSolarTimes = () => {
+  const offset = timezoneOffset(timezone);
+  const localOffset = timezoneOffsetLocal(timezone);
+
+  const today = new Date();
+  const tomorrow = new Date(today);
+  const yesterday = new Date(today);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  yesterday.setDate(yesterday.getDate() - 1);
+
+  const isAfterNoon = today.getUTCHours() - offset >= 12;
+  const dates = isAfterNoon ? [today, tomorrow] : [yesterday, today];
+
+  const { sunset, night } = getTimes(dates[0], lat, long, altitude);
+  const { nightEnd: dawn, sunrise } = getTimes(dates[1], lat, long, altitude);
+
+  return dates.map((date, i) => {
+    const times = i === 0 ? [sunset, night] : [dawn, sunrise];
+
+    times.forEach((time) => {
+      time.setHours(time.getHours() - localOffset);
+    });
+
+    return { date, times };
+  });
+};
+
+export default function handler(req, res) {
+  const lunarTimes = getLunarTimes();
+  const { phase: lunarPhase } = getMoonIllumination();
+  const solarTimes = getSolarTimes();
+
+  if (!lunarTimes || !lunarPhase || !solarTimes) {
+    throw new Error("An error occurred while retrieving astroweather data.");
+  }
+
+  return res.status(200).json({ lunarTimes, lunarPhase, solarTimes });
+}


### PR DESCRIPTION
Move all astroweather calcs into a single API that returns lunar phase, lunar times, and sun times via useSWR hook.

Removed redundant code and updated some props