### PR TITLE
[C] use original URL for GIF

### DIFF
--- a/lib/api/fragments/image.js
+++ b/lib/api/fragments/image.js
@@ -38,4 +38,7 @@ cantoAssetSingle {
     CaptionES
     Credit
   }
+  fileInfo: metadata {
+    fileType: FileTypeExtension
+  }
 }`;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -418,7 +418,13 @@ export const imageShaper = (site, data, className) => {
 
   const key = localeKeys[site];
 
-  const { metadata, url, width, height } = data;
+  const {
+    metadata,
+    url,
+    width,
+    height,
+    fileInfo: { fileType },
+  } = data;
   const { directUrlPreview = "", directUrlOriginal = "", preview = "" } = url;
 
   const urlWithoutConstraint = directUrlPreview.slice(0, -3);
@@ -427,10 +433,15 @@ export const imageShaper = (site, data, className) => {
   const altText = metadata[`AltText${key}`];
   const caption = metadata[`Caption${key}`];
   const credit = metadata.Credit;
+  const useOriginal = fileType === "gif";
 
   return {
-    url: `${urlWithoutConstraint}${Math.floor(constraint / 3)}`,
-    url2x: `${urlWithoutConstraint}${Math.floor(constraint / 2)}`,
+    url: useOriginal
+      ? directUrlOriginal
+      : `${urlWithoutConstraint}${Math.floor(constraint / 3)}`,
+    url2x: useOriginal
+      ? directUrlOriginal
+      : `${urlWithoutConstraint}${Math.floor(constraint / 2)}`,
     url3x: directUrlOriginal,
     thumb: preview,
     width: Number(width),

--- a/yarn.lock
+++ b/yarn.lock
@@ -4325,9 +4325,9 @@ camelize@^1.0.0:
   integrity sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==
 
 caniuse-lite@^1.0.30001400, caniuse-lite@^1.0.30001406, caniuse-lite@^1.0.30001449, caniuse-lite@^1.0.30001464, caniuse-lite@^1.0.30001503:
-  version "1.0.30001508"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001508.tgz"
-  integrity sha512-sdQZOJdmt3GJs1UMNpCCCyeuS2IEGLXnHyAo9yIO5JJDjbjoVRij4M1qep6P6gFpptD1PqIYgzM+gwJbOi92mw==
+  version "1.0.30001578"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001578.tgz"
+  integrity sha512-J/jkFgsQ3NEl4w2lCoM9ZPxrD+FoBNJ7uJUpGVjIg/j0OwJosWM36EPDv+Yyi0V4twBk9pPmlFS+PLykgEvUmg==
 
 case-sensitive-paths-webpack-plugin@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
Canto's preview URL's are always in JPG format, this breaks GIF formats on smaller screen sizes. Short circuit this behavior by adding filetype to the asset query and using the original URL instead. 