### PR TITLE
Homepage tweaks

### DIFF
--- a/components/content-blocks/Callout/CalloutEntry/index.js
+++ b/components/content-blocks/Callout/CalloutEntry/index.js
@@ -68,7 +68,7 @@ export default function CalloutEntry({ callout }) {
 
   return (
     <Styled.Section $bgColor={backgroundColor} $width="full" $overlay={false}>
-      <Styled.Inner href={url} aria-labelledby={titleId}>
+      <Styled.Inner $isImage={!!calloutImage}>
         {calloutImage && (
           <Styled.ImageWrapper>
             <Image role="presentation" ratio="4:3" image={calloutImage} />
@@ -88,7 +88,11 @@ export default function CalloutEntry({ callout }) {
           />
         )}
         <Styled.Footer>
-          <Styled.FooterButton className={`c-buttonish c-buttonish--inert`}>
+          <Styled.FooterButton
+            href={url}
+            aria-labelledby={titleId}
+            className={`c-buttonish c-buttonish--inert`}
+          >
             {t("read-more")}
           </Styled.FooterButton>
         </Styled.Footer>

--- a/components/content-blocks/Callout/CalloutEntry/styles.js
+++ b/components/content-blocks/Callout/CalloutEntry/styles.js
@@ -29,9 +29,8 @@ export const Section = styled(CalloutSection)`
   position: relative;
 `;
 
-export const Inner = styled(MixedLink)`
+export const Inner = styled.div`
   ${containerRegular()}
-  position: ${(p) => p.$position};
   display: grid;
   grid-template-areas:
     "image title"
@@ -49,6 +48,20 @@ export const Inner = styled(MixedLink)`
   padding-bottom: ${fluidScale("50px", "40px")};
   text-decoration: none;
   transition: color 0.2s, background-color 0.2s;
+
+  ${({ $isImage }) =>
+    !$isImage &&
+    `
+    grid-template-areas:
+      "image image"
+      "title title"
+      "subtitle subtitle"
+      "text text"
+      "footer footer";
+    gap: 0;
+    justify-content: center;
+    text-align: center;
+  `}
 
   ${respond(
     `
@@ -174,18 +187,19 @@ export const Footer = styled.div`
   grid-area: footer;
   grid-template-columns: max-content 1fr;
   place-items: end;
-  margin-top: 15px;
+  margin: 15px 0 0;
+
+  ${({ $isImage }) =>
+    !$isImage &&
+    `
+    margin: 15px auto 0;
+    grid-template-columns: 1fr;
+  `}
 
   ${respond(`grid-template-columns: 1fr;`)}
 `;
 
-export const FooterButton = styled.div`
-  ${Inner}:hover &,
-  ${Inner}:focus-visible & {
-    outline: 3px solid var(--button-border-color);
-    outline-offset: 1px;
-  }
-
+export const FooterButton = styled(MixedLink)`
   ${respond(
     `
     display: block;

--- a/components/content-blocks/Callout/CalloutMain.js
+++ b/components/content-blocks/Callout/CalloutMain.js
@@ -25,6 +25,7 @@ export default function CalloutMain({ callout }) {
     <Wrapper
       {...wrapperProps}
       height={dynamicComponent === "alertStream" ? "slim" : ""}
+      isImage={!!calloutImage}
     >
       <Header>
         <h2>{header}</h2>

--- a/components/content-blocks/Callout/CalloutTwoTone.js
+++ b/components/content-blocks/Callout/CalloutTwoTone.js
@@ -30,7 +30,12 @@ export default function CalloutTwoTone({ callout }) {
 
   return (
     <>
-      <Wrapper backgroundColor={backgroundColor} order="image" stack="top">
+      <Wrapper
+        backgroundColor={backgroundColor}
+        order="image"
+        stack="top"
+        isImage={!!image?.[0]}
+      >
         <Header>
           <h2>{header}</h2>
           {text && (

--- a/components/content-blocks/Callout/Wrapper.js
+++ b/components/content-blocks/Callout/Wrapper.js
@@ -10,10 +10,17 @@ export default function CalloutWrapper({
   ratio = "50",
   stack,
   width = "full",
+  isImage,
 }) {
   return (
     <Section $bgColor={backgroundColor} $width={width} $overlay={overlay}>
-      <Inner $order={order} $ratio={ratio} $height={height} $stack={stack}>
+      <Inner
+        $isImage={isImage}
+        $order={order}
+        $ratio={ratio}
+        $height={height}
+        $stack={stack}
+      >
         {children}
       </Inner>
     </Section>
@@ -31,4 +38,5 @@ CalloutWrapper.propTypes = {
   ratio: PropTypes.string,
   stack: PropTypes.string,
   width: PropTypes.string,
+  isImage: PropTypes.bool,
 };

--- a/components/content-blocks/Callout/styles.js
+++ b/components/content-blocks/Callout/styles.js
@@ -39,6 +39,16 @@ export const Inner = styled.div`
   padding-top: ${fluidScale("50px", "30px")};
   padding-bottom: ${fluidScale("50px", "40px")};
 
+  ${(p) =>
+    !p.$isImage &&
+    `
+    grid-template:
+      "text" auto / 100%;
+    gap: ${gap};
+    justify-content: center;
+    text-align: center;
+  `}
+
   ${respond(
     `
     grid-template:

--- a/components/content-blocks/GridBlock/index.js
+++ b/components/content-blocks/GridBlock/index.js
@@ -56,16 +56,18 @@ export default function GridBlock({
   return (
     <Container width={containerWidth}>
       <div>
-        <Header
-          className={
-            typeHandle === "investigationGrid" ? "t-align-center" : undefined
-          }
-          addBorder={
-            typeHandle === "relatedContent" || typeHandle === "staffGrid"
-          }
-        >
-          {header}
-        </Header>
+        {header && (
+          <Header
+            className={
+              typeHandle === "investigationGrid" ? "t-align-center" : undefined
+            }
+            addBorder={
+              typeHandle === "relatedContent" || typeHandle === "staffGrid"
+            }
+          >
+            {header}
+          </Header>
+        )}
         <ContentGrid
           items={items}
           limit={limit}

--- a/components/layout/ChildNavigation/index.js
+++ b/components/layout/ChildNavigation/index.js
@@ -12,7 +12,9 @@ function ChildNavigation({ pages, ...props }) {
     };
   });
 
-  return <StepNavigation pages={mappedPages} columns={1} {...props} />;
+  return (
+    <StepNavigation pages={mappedPages} expandable columns={1} {...props} />
+  );
 }
 
 ChildNavigation.propTypes = {

--- a/components/layout/StepNavigation/index.js
+++ b/components/layout/StepNavigation/index.js
@@ -34,48 +34,52 @@ export default function StepNavigation({
   });
 
   useEffect(() => {
-    if (isBreakpoint) {
+    if (isBreakpoint && !isOpen) {
       setIsOpen(true);
     }
-  });
+  }, [isBreakpoint, isOpen, setIsOpen]);
 
   if (!pages?.length) return null;
 
   return (
     <Container width="regular" bgColor="orange02" paddingSize="medium">
-      <Styled.Wrapper ref={ref}>
-        <Styled.Title>
-          <h2>{title}</h2>
-          {expandable && (
-            <ExpandToggle
-              onClick={onToggle}
-              isOpen={isOpen}
-              controlsId="guideNavList"
-            />
-          )}
-          {description && (
-            <Styled.Description
-              dangerouslySetInnerHTML={{ __html: description }}
-            />
-          )}
-        </Styled.Title>
-        <Styled.NavList id="guideNavList" $columns={columns} open={isOpen}>
-          {pages.map((page, i) => (
-            <Styled.NavItem
-              key={i}
-              $active={page.url === currentUri}
-              $showBorder={getShowBorder(i + 1, pages.length, columns)}
-            >
-              <Styled.NavLink
-                url={page.url}
-                aria-current={page.url === currentUri ? "page" : undefined}
+      <div ref={ref}>
+        <Styled.Wrapper>
+          <Styled.Header>
+            <Styled.TitleDescription>
+              <h2>{title}</h2>
+              {description && (
+                <Styled.Description
+                  dangerouslySetInnerHTML={{ __html: description }}
+                />
+              )}
+            </Styled.TitleDescription>
+            {expandable && (
+              <ExpandToggle
+                onClick={onToggle}
+                isOpen={isOpen}
+                controlsId="guideNavList"
+              />
+            )}
+          </Styled.Header>
+          <Styled.NavList id="guideNavList" $columns={columns} open={isOpen}>
+            {pages.map((page, i) => (
+              <Styled.NavItem
+                key={i}
+                $active={page.url === currentUri}
+                $showBorder={getShowBorder(i + 1, pages.length, columns)}
               >
-                <span>{page.title}</span>
-              </Styled.NavLink>
-            </Styled.NavItem>
-          ))}
-        </Styled.NavList>
-      </Styled.Wrapper>
+                <Styled.NavLink
+                  url={page.url}
+                  aria-current={page.url === currentUri ? "page" : undefined}
+                >
+                  <span>{page.title}</span>
+                </Styled.NavLink>
+              </Styled.NavItem>
+            ))}
+          </Styled.NavList>
+        </Styled.Wrapper>
+      </div>
     </Container>
   );
 }

--- a/components/layout/StepNavigation/styles.js
+++ b/components/layout/StepNavigation/styles.js
@@ -9,17 +9,27 @@ export const Wrapper = styled.div`
   margin-block-end: -18px;
   margin-inline-start: -50px;
 
+  ${respond(
+    `
+    flex-direction: column;
+    align-items: stretch;
+  `,
+    tokens.BREAK_PHABLET
+  )}
+
   > * {
     margin-block-end: 18px;
     margin-inline-start: 50px;
   }
 `;
 
-export const Title = styled.div`
+export const Header = styled.div`
   display: flex;
   flex: 666 1 0%;
-  flex-wrap: nowrap;
+  flex-flow: column nowrap;
   justify-content: space-between;
+
+  ${respond(`flex-direction: row;`, tokens.BREAK_PHABLET)}
 
   h2 {
     flex-grow: 1;
@@ -29,10 +39,20 @@ export const Title = styled.div`
     display: none;
     flex-shrink: 0;
     align-self: center;
-    padding-left: 10px;
+    padding-left: 20px;
 
     ${respond(`display: flex;`, tokens.BREAK_PHABLET)}
   }
+`;
+
+export const TitleDescription = styled.div`
+  ${respond(
+    `
+    display: flex;
+    flex-direction: column;
+  `,
+    tokens.BREAK_PHABLET
+  )}
 `;
 
 export const Description = styled.div`
@@ -41,9 +61,7 @@ export const Description = styled.div`
 
 export const NavList = styled.ol`
   position: relative;
-  flex: 1 1
-    ${({ $columns }) =>
-      fluidScale(`${400 * $columns}px`, `${300 * $columns}px`)};
+  flex: 1 1 auto;
   columns: ${({ $columns }) => $columns};
   column-gap: ${fluidScale("50px", "30px")};
   max-height: 0;

--- a/components/page/Breadcrumbs/styles.js
+++ b/components/page/Breadcrumbs/styles.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import CommonJsBreadcrumbs from "@castiron/components-breadcrumbs";
-import { containerRegular, respond } from "@/styles/globalStyles";
+import { containerRegular, respond, tokens } from "@/styles/globalStyles";
 
 // eslint-disable-next-line react/prop-types
 const BreadcrumbsWrapper = ({ className, ...restProps }) => {
@@ -25,10 +25,11 @@ export const Breadcrumbs = styled(BreadcrumbsWrapper)`
   font-weight: 700;
   background-color: var(--neutral10);
 
-  ${respond(`display: none;`, "450px")}
+  ${respond(`display: none;`, tokens.BREAK_PHABLET)}
 
   &__ol {
     display: flex;
+    flex-wrap: wrap;
 
     ${({ $type }) =>
       $type === "search"

--- a/components/page/Hero/index.js
+++ b/components/page/Hero/index.js
@@ -1,40 +1,37 @@
 import PropTypes from "prop-types";
-import styled from "styled-components";
-import { Image } from "@rubin-epo/epo-react-lib";
 import imageShape from "@/shapes/image";
-import { fluidScale, containerFullBleed } from "@/styles/globalStyles";
+import * as Styled from "./styles";
 
-export default function Hero({ data, className, children }) {
+export default function Hero({
+  data,
+  focalPointX,
+  focalPointY,
+  className,
+  children,
+}) {
   const imageData = data && data[0];
 
   if (!imageData?.url) return null;
 
   return (
-    <StyledHero className={className}>
-      <StyledImage role="presentation" image={imageData} />
+    <Styled.HeroContainer className={className}>
+      <Styled.HeroImage
+        $focalPointX={focalPointX || 50}
+        $focalPointY={focalPointY || 50}
+        role="presentation"
+        image={imageData}
+      />
       {children}
-    </StyledHero>
+    </Styled.HeroContainer>
   );
 }
 
-const StyledHero = styled.div`
-  ${containerFullBleed("CONTAINER_FULL")}
-  position: relative;
-  height: var(--Hero-height, ${fluidScale("540px", "400px")});
-  overflow: auto;
-`;
-
-const StyledImage = styled(Image)`
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  object-position: var(--Hero-object-position, center);
-  transform: var(--Hero-transform);
-`;
 Hero.displayName = "Global.Hero";
 
 Hero.propTypes = {
   data: PropTypes.arrayOf(imageShape),
   children: PropTypes.node,
   className: PropTypes.string,
+  focalPointX: PropTypes.number,
+  focalPointY: PropTypes.number,
 };

--- a/components/page/Hero/styles.js
+++ b/components/page/Hero/styles.js
@@ -1,0 +1,20 @@
+import styled from "styled-components";
+import { fluidScale, containerFullBleed } from "@/styles/globalStyles";
+import { Image } from "@rubin-epo/epo-react-lib";
+
+export const HeroContainer = styled.div`
+  ${containerFullBleed("CONTAINER_FULL")}
+  position: relative;
+  height: var(--Hero-height, ${fluidScale("540px", "400px")});
+  overflow: auto;
+`;
+
+export const HeroImage = styled(Image)`
+  --Hero-object-position: ${({ $focalPointX, $focalPointY }) =>
+    `${$focalPointX}% ${$focalPointY}%;`}
+  width: 100%;
+
+  height: 100%;
+  object-fit: cover;
+  object-position: var(--Hero-object-position, center);
+`;

--- a/components/page/PageContent/index.js
+++ b/components/page/PageContent/index.js
@@ -4,6 +4,8 @@ import * as Styled from "./styles";
 function PageContent({
   innerHero,
   heroImage,
+  focalPointX,
+  focalPointY,
   children,
   sidebar,
   footer,
@@ -15,7 +17,11 @@ function PageContent({
   if (!overlapHero) {
     return (
       <>
-        {hasHero && <Styled.Hero data={heroImage}>{innerHero}</Styled.Hero>}
+        {hasHero && (
+          <Styled.Hero data={heroImage} {...{ focalPointX, focalPointY }}>
+            {innerHero}
+          </Styled.Hero>
+        )}
         <Styled.FullLayout $hasSidebar={hasSidebar}>
           <div>{children}</div>
           {!!sidebar && <Styled.Aside>{sidebar}</Styled.Aside>}
@@ -27,7 +33,11 @@ function PageContent({
 
   return (
     <>
-      {<Styled.Hero data={heroImage}>{innerHero}</Styled.Hero>}
+      {hasHero && (
+        <Styled.Hero data={heroImage} {...{ focalPointX, focalPointY }}>
+          {innerHero}
+        </Styled.Hero>
+      )}
       <Styled.OverlapLayout $hasSidebar={hasSidebar}>
         <Styled.Main>{children}</Styled.Main>
         {!!sidebar && <Styled.Aside>{sidebar}</Styled.Aside>}
@@ -44,6 +54,8 @@ PageContent.propTypes = {
   sidebar: PropTypes.node,
   footer: PropTypes.node,
   overlapHero: PropTypes.bool,
+  focalPointX: PropTypes.number,
+  focalPointY: PropTypes.number,
 };
 
 export default PageContent;

--- a/components/page/PageContent/styles.js
+++ b/components/page/PageContent/styles.js
@@ -22,10 +22,9 @@ export const Hero = styled(HeroComponent)`
     WIDE_BREAKPOINT,
     MOBILE_BREAKPOINT
   )};
-  --Hero-object-position: 42.5% 50%;
+  --Hero-object-position: ${({ $focalPointX, $focalPointY }) =>
+    `${$focalPointX}% ${$focalPointY}%;`}
   --hero-overlap: ${HERO_OVERLAP};
-
-  ${respond(`--Hero-transform: translateY(-10%);`, MOBILE_BREAKPOINT)}
 `;
 
 export const FullLayout = styled.article`

--- a/components/templates/EventPage/index.js
+++ b/components/templates/EventPage/index.js
@@ -1,5 +1,4 @@
 import PropTypes from "prop-types";
-import styled from "styled-components";
 import { useTranslation } from "react-i18next";
 import {
   checkIfBetweenDates,
@@ -14,6 +13,7 @@ import Breadcrumbs from "@/page/Breadcrumbs";
 import { Container } from "@rubin-epo/epo-react-lib";
 import EventList from "@/dynamic/EventList";
 import EventTime from "@/components/EventTime";
+import * as Styled from "./styles";
 
 export default function EventPage({
   data: {
@@ -30,6 +30,8 @@ export default function EventPage({
     eventType = [],
     featuredImage = [],
     hero = [],
+    focalPointX,
+    focalPointY,
     id,
     registrationCloseDate,
     registrationOpenDate,
@@ -70,16 +72,16 @@ export default function EventPage({
   return (
     <Body {...bodyProps}>
       <Breadcrumbs breadcrumbs={[...customBreadcrumbs, pageLink]} />
-      <Hero data={hero} />
+      <Hero data={hero} {...{ focalPointX, focalPointY }} />
       <Container paddingSize="medium">
         <div>
           {eventType?.[0]?.title && (
-            <Pretitle className="t-heading-quaternary">
+            <Styled.Pretitle className="t-heading-quaternary">
               {eventType?.[0]?.title}
-            </Pretitle>
+            </Styled.Pretitle>
           )}
           <h1>{title}</h1>
-          <Subtitle>
+          <Styled.Subtitle>
             <div>{location}</div>
             <EventTime
               {...{
@@ -91,7 +93,7 @@ export default function EventPage({
               }}
             />
             {isThereRegistration && <div>{t(`events.${registration}`)}</div>}
-          </Subtitle>
+          </Styled.Subtitle>
         </div>
       </Container>
       <Share />
@@ -131,14 +133,6 @@ export default function EventPage({
     </Body>
   );
 }
-
-const Pretitle = styled.div`
-  padding-bottom: 10px;
-`;
-
-const Subtitle = styled.div`
-  padding-top: 10px;
-`;
 
 EventPage.displayName = "Template.EventPage";
 

--- a/components/templates/EventPage/styles.js
+++ b/components/templates/EventPage/styles.js
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+
+export const Pretitle = styled.div`
+  padding-bottom: 10px;
+`;
+
+export const Subtitle = styled.div`
+  padding-top: 10px;
+`;

--- a/components/templates/HomePage/index.js
+++ b/components/templates/HomePage/index.js
@@ -1,15 +1,14 @@
 import PropTypes from "prop-types";
-import styled from "styled-components";
 import { useTranslation } from "react-i18next";
 import Body from "@/global/Body";
 import ContentBlockFactory from "@/factories/ContentBlockFactory";
 import Hero from "@/page/Hero";
-import { respond } from "@/styles/globalStyles";
 import { Buttonish, MixedLink } from "@rubin-epo/epo-react-lib";
 import { makeDateString, makeTruncatedString } from "@/lib/utils";
 import { SlideBlock } from "@/components/content-blocks";
 import Tabs from "@/components/layout/Tabs";
 import TempList from "@/components/dynamic/TempList";
+import * as Styled from "./styles";
 
 export default function HomePage({
   data: { contentBlocks, customHero, description, hero, id, newsEntry, title },
@@ -77,17 +76,17 @@ export default function HomePage({
   return (
     <Body {...bodyProps}>
       {isAlternate ? (
-        <HeroWrapper>
-          {altFlag && <Flag>{altFlag}</Flag>}
-          <StyledNewsHero>
+        <Styled.HeroWrapper>
+          {altFlag && <Styled.Flag>{altFlag}</Styled.Flag>}
+          <Styled.NewsHero>
             <Hero data={altHero} />
-          </StyledNewsHero>
-          <HeroContent>
+          </Styled.NewsHero>
+          <Styled.HeroContent>
             {!custom && news?.postType?.[0]?.title && (
               <h4>{news.postType[0].title}</h4>
             )}
             <h1>{altHeader}</h1>
-            <Details>
+            <Styled.Details>
               <span>
                 {!custom && news?.date && <h4>{makeDateString(news.date)}</h4>}
                 <div>{makeTruncatedString(altTeaser, 30)}</div>
@@ -100,24 +99,24 @@ export default function HomePage({
                   url={`/${news.uri}`}
                 ></Buttonish>
               ) : null}
-            </Details>
-          </HeroContent>
-        </HeroWrapper>
+            </Styled.Details>
+          </Styled.HeroContent>
+        </Styled.HeroWrapper>
       ) : (
-        <HeroWrapper>
-          <StyledHero>
+        <Styled.HeroWrapper>
+          <Styled.HeroContainer>
             <Hero data={hero} />
-          </StyledHero>
-          <HeroContent>
+          </Styled.HeroContainer>
+          <Styled.HeroContent>
             <h1>{title}</h1>
-            <Details>{description}</Details>
-          </HeroContent>
-        </HeroWrapper>
+            <Styled.Details>{description}</Styled.Details>
+          </Styled.HeroContent>
+        </Styled.HeroWrapper>
       )}
       {sliderArray.length > 0 && (
-        <StyledTabs>
+        <Styled.TabsContainer>
           <Tabs labels={labelMap}>{Sliders}</Tabs>
-        </StyledTabs>
+        </Styled.TabsContainer>
       )}
       {[...finalContentBlocks].map((block) => {
         return (
@@ -132,71 +131,6 @@ export default function HomePage({
     </Body>
   );
 }
-
-const HeroWrapper = styled.div`
-  display: grid;
-  grid-template-columns: 40% 60%;
-  grid-template-rows: 50px 1fr;
-  gap: 0px 0px;
-  align-items: center;
-  background-color: var(--black);
-  ${respond(`grid-template-columns: 10% 90%;`)}
-`;
-
-const Flag = styled.h4`
-  grid-area: 1 / 1 / 2 / 3;
-  z-index: 1;
-  background-color: var(--red40);
-  color: var(--white);
-  place-self: start;
-  margin-left: 4vw;
-  padding: 1em 2em;
-`;
-
-const StyledNewsHero = styled.div`
-  border-top: 10px solid var(--red40);
-  grid-area: 1 / 1 / 3 / 3;
-  > div:first-child img {
-    filter: brightness(50%) grayscale(30%) sepia(60%) hue-rotate(320deg);
-    ${respond(`min-height: 75vh;`)}
-  }
-`;
-
-const StyledHero = styled.div`
-  grid-area: 1 / 1 / 3 / 3;
-
-  img {
-    ${respond(`min-height: 50vh;`)}
-  }
-`;
-
-const HeroContent = styled.div`
-  grid-area: 1 / 2 / 3 / 3;
-  z-index: 1;
-  padding-right: 2vw;
-  padding-bottom: 2em;
-  max-width: 40em;
-  color: var(--white);
-  text-shadow: 0px 0px 6px var(--black);
-  a {
-    text-shadow: none;
-  }
-  ${respond(`align-self: end;
-    padding-bottom: 110px;`)}
-`;
-
-const Details = styled.div`
-  a {
-    margin-top: 1em;
-  }
-  ${respond(`span {display: none;}`)}
-`;
-
-const StyledTabs = styled.div`
-  position: relative;
-  top: -60px;
-  ${respond(`top: -80px;`)}
-`;
 
 HomePage.displayName = "Template.HomePage";
 

--- a/components/templates/HomePage/index.js
+++ b/components/templates/HomePage/index.js
@@ -11,7 +11,17 @@ import TempList from "@/components/dynamic/TempList";
 import * as Styled from "./styles";
 
 export default function HomePage({
-  data: { contentBlocks, customHero, description, hero, id, newsEntry, title },
+  data: {
+    contentBlocks,
+    customHero,
+    description,
+    hero,
+    focalPointX,
+    focalPointY,
+    id,
+    newsEntry,
+    title,
+  },
 }) {
   const { t } = useTranslation();
   const bodyProps = {
@@ -79,7 +89,7 @@ export default function HomePage({
         <Styled.HeroWrapper>
           {altFlag && <Styled.Flag>{altFlag}</Styled.Flag>}
           <Styled.NewsHero>
-            <Hero data={altHero} />
+            <Hero data={altHero} {...{ focalPointX, focalPointY }} />
           </Styled.NewsHero>
           <Styled.HeroContent>
             {!custom && news?.postType?.[0]?.title && (
@@ -105,7 +115,7 @@ export default function HomePage({
       ) : (
         <Styled.HeroWrapper>
           <Styled.HeroContainer>
-            <Hero data={hero} />
+            <Hero data={hero} {...{ focalPointX, focalPointY }} />
           </Styled.HeroContainer>
           <Styled.HeroContent>
             <h1>{title}</h1>

--- a/components/templates/HomePage/styles.js
+++ b/components/templates/HomePage/styles.js
@@ -1,0 +1,77 @@
+import styled from "styled-components";
+import { respond } from "@/styles/globalStyles";
+
+export const HeroWrapper = styled.div`
+  display: grid;
+  grid-template-rows: 50px 1fr;
+  grid-template-columns: 40% 60%;
+  gap: 0px 0px;
+  align-items: center;
+  background-color: var(--black);
+  ${respond(`grid-template-columns: 10% 90%;`)}
+`;
+
+export const Flag = styled.h4`
+  z-index: 1;
+  grid-area: 1 / 1 / 2 / 3;
+  place-self: start;
+  padding: 1em 2em;
+  margin-left: 4vw;
+  color: var(--white);
+  background-color: var(--red40);
+`;
+
+export const NewsHero = styled.div`
+  grid-area: 1 / 1 / 3 / 3;
+  border-top: 10px solid var(--red40);
+
+  > div:first-child img {
+    filter: brightness(50%) grayscale(30%) sepia(60%) hue-rotate(320deg);
+    ${respond(`min-height: 75vh;`)}
+  }
+`;
+
+export const HeroContainer = styled.div`
+  grid-area: 1 / 1 / 3 / 3;
+
+  img {
+    ${respond(`min-height: 50vh;`)}
+  }
+`;
+
+export const HeroContent = styled.div`
+  z-index: 1;
+  grid-area: 1 / 2 / 3 / 3;
+  max-width: 40em;
+  padding-right: 2vw;
+  padding-bottom: 2em;
+  color: var(--white);
+  text-shadow: 0px 0px 8px var(--black);
+
+  a {
+    text-shadow: none;
+  }
+
+  ${respond(`
+    align-self: end;
+    padding-bottom: 110px;
+  `)}
+`;
+
+export const Details = styled.div`
+  a {
+    margin-top: 1em;
+  }
+
+  ${respond(`
+    span {
+      display: none;
+    }
+  `)}
+`;
+
+export const TabsContainer = styled.div`
+  position: relative;
+  top: -60px;
+  ${respond(`top: -80px;`)}
+`;

--- a/components/templates/NewsPage/NewsHero.js
+++ b/components/templates/NewsPage/NewsHero.js
@@ -2,7 +2,14 @@ import PropTypes from "prop-types";
 import imageShape from "@/shapes/image";
 import * as Styled from "./styles";
 
-export default function NewsHero({ data, className, caption, children }) {
+export default function NewsHero({
+  data,
+  className,
+  caption,
+  children,
+  focalPointX,
+  focalPointY,
+}) {
   const imageData = data && data[0];
 
   if (!imageData?.url) return null;
@@ -11,7 +18,11 @@ export default function NewsHero({ data, className, caption, children }) {
     return (
       <Styled.HeroFigure className={className}>
         <Styled.HeroImageContainer>
-          <Styled.HeroImage image={imageData} />
+          <Styled.HeroImage
+            image={imageData}
+            $focalPointX={focalPointX || 50}
+            $focalPointY={focalPointY || 50}
+          />
         </Styled.HeroImageContainer>
         <Styled.HeroFigCaption dangerouslySetInnerHTML={{ __html: caption }} />
       </Styled.HeroFigure>
@@ -19,7 +30,12 @@ export default function NewsHero({ data, className, caption, children }) {
 
   return (
     <Styled.Hero className={className}>
-      <Styled.HeroImage role="presentation" image={imageData} />
+      <Styled.HeroImage
+        role="presentation"
+        image={imageData}
+        $focalPointX={focalPointX || 50}
+        $focalPointY={focalPointY || 50}
+      />
       {children}
     </Styled.Hero>
   );
@@ -30,4 +46,6 @@ NewsHero.propTypes = {
   data: PropTypes.arrayOf(imageShape),
   children: PropTypes.node,
   caption: PropTypes.string,
+  focalPointX: PropTypes.number,
+  focalPointY: PropTypes.number,
 };

--- a/components/templates/NewsPage/index.js
+++ b/components/templates/NewsPage/index.js
@@ -25,6 +25,8 @@ export default function NewsPage({ data }) {
     headline,
     featuredImage = [],
     hero = [],
+    focalPointX,
+    focalPointY,
     heroCaption,
     id,
     newsAssets,
@@ -97,6 +99,7 @@ export default function NewsPage({ data }) {
             : makeReleaseFeature(releaseImages, "banner1920")
         }
         narrowCaption={showAside}
+        {...{ focalPointX, focalPointY }}
       />
       <Styled.NewsDetail $showAside={showAside}>
         {(entryWithRelease || data) && (

--- a/components/templates/NewsPage/styles.js
+++ b/components/templates/NewsPage/styles.js
@@ -46,11 +46,13 @@ export const HeroCaption = styled.div`
 `;
 
 export const HeroImage = styled(Image)`
+  --Hero-object-position: ${({ $focalPointX, $focalPointY }) =>
+    `${$focalPointX}% ${$focalPointY}%;`}
   width: 100%;
+
   height: 100%;
   object-fit: cover;
   object-position: var(--Hero-object-position, center);
-  transform: var(--Hero-transform);
 `;
 
 export const Article = styled.article`

--- a/components/templates/Page/index.js
+++ b/components/templates/Page/index.js
@@ -27,6 +27,8 @@ export default function Page({
     dynamicComponent,
     featuredImage,
     hero,
+    focalPointX,
+    focalPointY,
     hideTitle,
     id,
     pageType = "standard",
@@ -133,7 +135,11 @@ export default function Page({
           />
         )}
         {hasFilterbar && <FilterBar filterType={dynamicComponent} />}
-        <PageContent heroImage={hero} overlapHero={shouldOverlapHero}>
+        <PageContent
+          heroImage={!showSiblingNav && hero}
+          overlapHero={showSiblingNav ? false : shouldOverlapHero}
+          {...{ focalPointX, focalPointY }}
+        >
           <SubHero
             type={typeHandle}
             header={subHeroHeader}

--- a/lib/api/fragments/educator-page.js
+++ b/lib/api/fragments/educator-page.js
@@ -27,6 +27,8 @@ fragment educatorPageFragmentFull on pages_educatorPages_Entry {
         ${getImageFields("crop", 1920, 1067)}
       }
     }
+    focalPointX
+    focalPointY
     overlapHero
     hideTitle
     pageType

--- a/lib/api/fragments/event.js
+++ b/lib/api/fragments/event.js
@@ -14,13 +14,13 @@ export const eventFragment = `
       startDate
       endDate: date
       description
-      hero {
-        ...on heroes_Asset {
+      image: featuredImage {
+        ...on contentImages_Asset {
           ${getImageFields("crop", 400, 400)}
         }
       }
-      image: featuredImage {
-        ...on contentImages_Asset {
+      hero {
+        ...on heroes_Asset {
           ${getImageFields("crop", 400, 400)}
         }
       }
@@ -52,7 +52,9 @@ export const eventFragmentFull = `
         ...on heroes_Asset {
           ${getImageFields("crop", 1920, 1067)}
         }
-      } 
+      }
+      focalPointX
+      focalPointY
       image: featuredImage {
         ...on contentImages_Asset {
           ${getImageFields("crop", 800, 800)}

--- a/lib/api/fragments/homepage.js
+++ b/lib/api/fragments/homepage.js
@@ -12,6 +12,8 @@ fragment homepageFragmentFull on homepage_homepage_Entry {
         ${getImageFields("crop", 1920, 1067)}
       }
     }
+    focalPointX
+    focalPointY
     newsEntry {
       ... on news_post_Entry {
         id

--- a/lib/api/fragments/news-post.js
+++ b/lib/api/fragments/news-post.js
@@ -11,13 +11,13 @@ export const newsPostFragment = `
       dateCreated
       description: teaser
       pressReleaseId
-      hero {
-        ...on heroes_Asset {
+      image: featuredImage {
+        ...on contentImages_Asset {
           ${getImageFields("crop", 900, 550)}
         }
       }
-      image: featuredImage {
-        ...on contentImages_Asset {
+      hero {
+        ...on heroes_Asset {
           ${getImageFields("crop", 900, 550)}
         }
       }
@@ -62,6 +62,8 @@ export const newsPostFragmentFull = `
           ${getImageFields("crop", 1920, 1067)}
         }
       }
+      focalPointX
+      focalPointY
       heroCaption: captionRichText 
       image: featuredImage {
         ...on contentImages_Asset {

--- a/lib/api/fragments/page.js
+++ b/lib/api/fragments/page.js
@@ -27,6 +27,8 @@ fragment pageFragmentFull on pages_pages_Entry {
         ${getImageFields("crop", 1920, 1067)}
       }
     }
+    focalPointX
+    focalPointY
     overlapHero
     hideTitle
     pageType

--- a/lib/api/fragments/student-page.js
+++ b/lib/api/fragments/student-page.js
@@ -26,6 +26,8 @@ fragment studentPageFragmentFull on pages_studentPages_Entry {
         ${getImageFields("crop", 1920, 1067)}
       }
     }
+    focalPointX
+    focalPointY
     overlapHero
     hideTitle
     pageType


### PR DESCRIPTION
- More drop shadow on Hero text
- Heading is optional for GridBlock (CTAGrid)
- Hero image positionable via focalPoint values
- StepNavigation mobile and desktop layouts more closely approximate original design
- Breadcrumb wraps and never overflows
- Breadcrumb hidden on screens >= 600px wide (wider than previously)
- New center aligned layout for Callouts without images