### PR TITLE
3 level desktop nav

### DIFF
--- a/components/global/Header/NavItemWithChildren.js
+++ b/components/global/Header/NavItemWithChildren.js
@@ -9,12 +9,15 @@ import internalLinkShape, { internalLinkInternalShape } from "@/shapes/link";
 export default function NavItemWithChildren({
   id,
   active,
+  parentActive,
   title,
   uri,
   childItems,
   onToggleClick,
   onEsc,
   theme,
+  baseClassName = "c-nav-list",
+  level = 2,
 }) {
   const ref = useRef(null);
 
@@ -30,24 +33,30 @@ export default function NavItemWithChildren({
   const childrenWithParent = [parent].concat(childItems);
 
   return (
-    <div ref={ref}>
+    <div ref={ref} className={`${baseClassName}__item-inner`}>
       <button
         onClick={() => onToggleClick(id)}
         aria-expanded={active}
         aria-haspopup
         className={classNames({
-          "c-nav-list__link": true,
-          "c-nav-list__link--is-active": active,
-          [`c-nav-list__link--${theme}`]: !!theme,
+          [`${baseClassName}__link`]: true,
+          [`${baseClassName}__link--is-active`]: active,
+          [`${baseClassName}__link--${theme}`]: !!theme,
         })}
       >
-        <IconComposer icon="ChevronThin" className="c-nav-list__link-icon" />
-        <span className="c-nav-list__link-text">{title}</span>
+        <IconComposer
+          icon="ChevronThin"
+          className={`${baseClassName}__link-icon`}
+        />
+        <span className={`${baseClassName}__link-text`}>{title}</span>
       </button>
       <Subnavigation
         items={childrenWithParent}
-        active={active}
+        active={level === 3 ? parentActive && active : active}
         onClick={onEsc}
+        theme={theme}
+        level={3}
+        baseClassName={level === 3 ? baseClassName : "c-subnav-list"}
       />
     </div>
   );
@@ -59,8 +68,11 @@ NavItemWithChildren.displayName =
 NavItemWithChildren.propTypes = {
   ...internalLinkInternalShape,
   active: PropTypes.bool,
+  parentActive: PropTypes.bool,
   childItems: PropTypes.arrayOf(internalLinkShape),
   onToggleClick: PropTypes.func.isRequired,
   onEsc: PropTypes.func.isRequired,
   theme: PropTypes.oneOf(["desktop", "mobile"]),
+  baseClassName: PropTypes.string,
+  level: PropTypes.number,
 };

--- a/components/global/Header/Navigation.js
+++ b/components/global/Header/Navigation.js
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useEffect, useState, useRef } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import { useTranslation } from "react-i18next";
@@ -13,6 +13,7 @@ export default function Navigation({
   items,
   userProfilePage,
   theme,
+  isOpenSetter,
   mobileActive,
   mobileSetter,
 }) {
@@ -27,12 +28,17 @@ export default function Navigation({
 
   useClickEvent(handleClick);
 
+  useEffect(() => {
+    if (isOpenSetter) isOpenSetter(!!active);
+  }, [mobileSetter, isOpenSetter, active]);
+
   function handleClick(e) {
     const isLink =
       e.target.nodeName === "A" || e.target.parentElement?.nodeName === "A";
     const isMobileLangSelect = e.target.id === mobileLangSelectId;
     if (mobileSetter && mobileActive && (isLink || isMobileLangSelect)) {
       mobileSetter(false);
+      setActive(null);
     }
     if (navList?.current?.contains(e.target)) return;
     setActive(null);
@@ -159,6 +165,7 @@ Navigation.propTypes = {
   items: PropTypes.arrayOf(internalLinkWithChildrenShape),
   userProfilePage: PropTypes.object,
   theme: PropTypes.oneOf(["desktop", "mobile"]),
+  isOpenSetter: PropTypes.func,
   mobileActive: PropTypes.bool,
   mobileSetter: PropTypes.func,
 };

--- a/components/global/Header/Navigation.js
+++ b/components/global/Header/Navigation.js
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from "react";
+import { useState, useRef } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import { useTranslation } from "react-i18next";
@@ -13,7 +13,7 @@ export default function Navigation({
   items,
   userProfilePage,
   theme,
-  isOpenSetter,
+  desktopSetter,
   mobileActive,
   mobileSetter,
 }) {
@@ -28,10 +28,6 @@ export default function Navigation({
 
   useClickEvent(handleClick);
 
-  useEffect(() => {
-    if (isOpenSetter) isOpenSetter(!!active);
-  }, [mobileSetter, isOpenSetter, active]);
-
   function handleClick(e) {
     const isLink =
       e.target.nodeName === "A" || e.target.parentElement?.nodeName === "A";
@@ -42,15 +38,17 @@ export default function Navigation({
     }
     if (navList?.current?.contains(e.target)) return;
     setActive(null);
+    if (desktopSetter) desktopSetter(false);
   }
 
   function handleToggleClick(id) {
     setActive((prevActive) => (prevActive === id ? null : id));
+    if (desktopSetter) desktopSetter(true);
   }
 
   function handleSignOut() {
     setActive(null);
-    mobileSetter(false);
+    if (mobileSetter) mobileSetter(false);
     signOut();
   }
 
@@ -165,7 +163,7 @@ Navigation.propTypes = {
   items: PropTypes.arrayOf(internalLinkWithChildrenShape),
   userProfilePage: PropTypes.object,
   theme: PropTypes.oneOf(["desktop", "mobile"]),
-  isOpenSetter: PropTypes.func,
+  desktopSetter: PropTypes.func,
   mobileActive: PropTypes.bool,
   mobileSetter: PropTypes.func,
 };

--- a/components/global/Header/Subnavigation.js
+++ b/components/global/Header/Subnavigation.js
@@ -1,34 +1,75 @@
+/* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
+/*
+ * Ignore false positives (key event exists on Navigation component; role attribute not needed
+ * since Link component validly handles href and window history, click just closes subnav)
+ */
+import { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import Link from "next/link";
 import classNames from "classnames";
 import internalLinkShape from "@/shapes/link";
+import NavItemWithChildren from "./NavItemWithChildren";
 
-export default function Subnavigation({ items, active, onClick }) {
-  /* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
-  /*
-   * Ignore false positives (key event exists on Navigation component; role attribute not needed
-   * since Link component validly handles href and window history, click just closes subnav)
-   */
+export default function Subnavigation({
+  items,
+  active,
+  onClick,
+  theme,
+  baseClassName = "c-subnav-list",
+  level = 2,
+}) {
+  const [activeSub, setActiveSub] = useState(null);
+
+  useEffect(() => {
+    if (!active) setActiveSub(null);
+  }, [active]);
+
+  function handleToggleClick(id) {
+    setActiveSub((prevActive) => (prevActive === id ? null : id));
+  }
+
   return (
     <ul
       className={classNames({
-        "c-subnav-list": true,
-        "c-subnav-list--is-active": active,
+        [baseClassName]: true,
+        [`${baseClassName}--is-active`]: active,
       })}
     >
-      {items.map(({ id, title, uri }) => (
-        <li key={id} className="c-subnav-list__item">
-          <Link
-            prefetch={false}
-            href={`/${uri}`}
-            className="c-subnav-list__link"
-            tabIndex={active ? 0 : -1}
-            onClick={onClick}
-          >
-            {title}
-          </Link>
-        </li>
-      ))}
+      {items.map(({ id, title, uri, children }) => {
+        const hasChildren = children && children.length > 0;
+        const isActiveSub = id === activeSub;
+
+        return (
+          <li key={id} className={`${baseClassName}__item`}>
+            {hasChildren && (
+              <NavItemWithChildren
+                id={id}
+                active={active && isActiveSub}
+                title={title}
+                uri={uri}
+                childItems={children}
+                onToggleClick={handleToggleClick}
+                onEsc={() => setActiveSub(null)}
+                theme={theme}
+                baseClassName="c-sub-subnav-list"
+                level={3}
+                parentActive={active}
+              />
+            )}
+            {!hasChildren && (
+              <Link
+                prefetch={false}
+                href={`/${uri}`}
+                className={`${baseClassName}__link`}
+                tabIndex={active ? 0 : -1}
+                onClick={onClick}
+              >
+                {title}
+              </Link>
+            )}
+          </li>
+        );
+      })}
     </ul>
   );
 }
@@ -39,4 +80,7 @@ Subnavigation.propTypes = {
   items: PropTypes.arrayOf(internalLinkShape),
   active: PropTypes.bool,
   onClick: PropTypes.func,
+  theme: PropTypes.oneOf(["desktop", "mobile"]),
+  baseClassName: PropTypes.string,
+  level: PropTypes.number,
 };

--- a/components/global/Header/_header.scss
+++ b/components/global/Header/_header.scss
@@ -59,6 +59,7 @@ $_breakpoint: functions.header(layout-breakpoint);
 
   &__search-block {
     grid-area: search;
+    background-color: functions.palette(turquoise60);
 
     @include base.respond($_breakpoint) {
       justify-self: end;
@@ -70,6 +71,7 @@ $_breakpoint: functions.header(layout-breakpoint);
     display: grid;
     grid-auto-flow: column;
     place-content: center;
+    background-color: functions.palette(turquoise60);
 
     fieldset {
       border: 0;
@@ -85,6 +87,7 @@ $_breakpoint: functions.header(layout-breakpoint);
     grid-area: user-nav;
     align-self: center;
     padding-right: 20px;
+    background-color: functions.palette(turquoise60);
 
     @include base.respond($_breakpoint) {
       padding-left: 0.65em;

--- a/components/global/Header/_navigation.scss
+++ b/components/global/Header/_navigation.scss
@@ -6,17 +6,10 @@ $_link-gap: 14px;
 
 .c-nav-list {
   @include base.fluid-scale(
-    nav-width,
-    functions.header(nav-width-desktop),
-    functions.header(nav-width-mobile),
-    functions.break(tablet),
-    functions.break(mobile)
-  );
-  @include base.fluid-scale(
     font-size,
     20px,
-    16px,
-    functions.break(tablet),
+    14px,
+    $_breakpoint,
     functions.break(mobile)
   );
 
@@ -67,11 +60,15 @@ $_link-gap: 14px;
   }
 
   &__lang {
-    width: var(--nav-width);
+    width: functions.header(nav-width-desktop);
     max-width: 53vw;
     padding-left: functions.header(nav-link-padding-lateral) * 1.5;
     padding-right: functions.header(nav-link-padding-lateral);
     background-color: functions.palette(turquoise60);
+
+    @include base.respond($_breakpoint) {
+      width: functions.header(nav-width-mobile);
+    }
 
     fieldset {
       height: var(--header-height);
@@ -83,7 +80,6 @@ $_link-gap: 14px;
   }
 
   &__link {
-    height: var(--header-height);
     padding-right: functions.header(nav-link-padding-lateral);
     padding-left: functions.header(nav-link-padding-lateral);
     text-decoration: none;
@@ -101,6 +97,7 @@ $_link-gap: 14px;
       display: flex;
       flex-direction: row-reverse;
       align-items: center;
+      height: var(--header-height);
       white-space: nowrap;
     }
 
@@ -108,8 +105,9 @@ $_link-gap: 14px;
       display: grid;
       grid-template: "icon text" auto / 24px auto;
       gap: $_link-gap;
-      width: var(--nav-width);
+      width: functions.header(nav-width-mobile);
       max-width: 53vw;
+      padding: functions.header(nav-link-padding-lateral);
     }
   }
 

--- a/components/global/Header/_subnavigation.scss
+++ b/components/global/Header/_subnavigation.scss
@@ -6,18 +6,17 @@ $_bg-color: functions.sass-palette(neutral02);
 .c-subnav-list {
   position: absolute;
   z-index: -5;
-  width: var(--nav-width);
   max-width: 47vw;
   max-height: calc(100vh - var(--header-height));
   overflow: auto;
   color: $_color;
-  background-color: $_bg-color;
   visibility: hidden;
   transition: transform 0.25s ease-in-out, visibility 0s 0.25s;
 
   .c-nav-list--mobile & {
     top: 0;
     left: 0;
+    width: functions.header(nav-width-mobile);
     height: 100%;
 
     &--is-active {
@@ -30,6 +29,7 @@ $_bg-color: functions.sass-palette(neutral02);
   .c-nav-list--desktop & {
     top: 100%;
     left: 0;
+    width: functions.header(nav-width-desktop);
     transform: translateY(-100%);
 
     &--is-active {
@@ -51,24 +51,32 @@ $_bg-color: functions.sass-palette(neutral02);
       height: 1px;
       content: "";
       background-color: currentcolor;
+
+      .c-nav-list--mobile & {
+        left: functions.header(nav-link-padding-lateral) / 2;
+        width: calc(100% - #{2 * functions.header(nav-link-padding-lateral) / 2});
+      }
     }
+
   }
 
   &__link {
     display: flex;
     align-items: center;
-    padding: 1.688em functions.header(nav-link-padding-lateral);
+    padding: functions.header(nav-link-padding-lateral);
     text-decoration: none;
+    background-color: $_bg-color;
     transition: color 0.2s, background-color 0.2s;
 
     &:hover,
-    &:focus-visible {
+    &:focus-visible,
+    &--is-active {
       color: functions.palette(white);
       background-color: functions.palette(turquoise50);
     }
 
     .c-nav-list--mobile & {
-      height: functions.header(height);
+      padding: 0.8em functions.header(nav-link-padding-lateral);
     }
   }
 }

--- a/components/global/Header/_subsubnavigation.scss
+++ b/components/global/Header/_subsubnavigation.scss
@@ -8,15 +8,23 @@ $_button-bg-color: functions.sass-palette(neutral02);
   height: 100%;
   max-height: 0;
   margin-left: functions.header(nav-link-padding-lateral) / 2;
-  overflow: auto;
+  overflow: hidden;
   color: $_color;
   visibility: hidden;
   transition: max-height 0.25s ease-out, visibility 0s 0.25s;
 
+  @keyframes hide-scroll {
+    from, to {
+      overflow: hidden;
+    }
+  }
+
   &--is-active {
     max-height: calc(100vh - var(--header-height));
+    overflow: auto;
     visibility: visible;
-    transition: max-height 0.5s ease-out;
+    transition: max-height 0.5s ease-in;
+    animation: hide-scroll 0.5s backwards;
   }
 
   &__item {

--- a/components/global/Header/_subsubnavigation.scss
+++ b/components/global/Header/_subsubnavigation.scss
@@ -1,0 +1,108 @@
+@use "abstracts/functions";
+
+$_color: functions.sass-palette(neutral80);
+$_bg-color: #E8E8E8;
+$_button-bg-color: functions.sass-palette(neutral02);
+
+.c-sub-subnav-list {
+  height: 100%;
+  max-height: 0;
+  margin-left: functions.header(nav-link-padding-lateral) / 2;
+  overflow: auto;
+  color: $_color;
+  visibility: hidden;
+  transition: max-height 0.25s ease-out, visibility 0s 0.25s;
+
+  &--is-active {
+    max-height: calc(100vh - var(--header-height));
+    visibility: visible;
+    transition: max-height 0.5s ease-out;
+  }
+
+  &__item {
+    position: relative;
+
+    &:first-child::after {
+      position: absolute;
+      bottom: 0;
+      left: functions.header(nav-link-padding-lateral);
+      display: block;
+      width: calc(100% - #{2 * functions.header(nav-link-padding-lateral)});
+      height: 1px;
+      content: "";
+      background-color: currentcolor;
+
+      .c-nav-list--mobile & {
+        left: functions.header(nav-link-padding-lateral) / 2;
+        width: calc(100% - #{2 * functions.header(nav-link-padding-lateral) / 2});
+      }
+    }
+  }
+
+  &__link {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    text-decoration: none;
+    background-color: $_bg-color;
+    transition: color 0.2s, background-color 0.2s;
+
+    &:hover,
+    &:focus-visible,
+    &--is-active {
+      color: functions.palette(white);
+      background-color: functions.palette(turquoise50);
+    }
+
+    .c-subnav-list__item & {
+      justify-content: space-between;
+      flex-direction: row-reverse;
+    }
+
+    .c-sub-subnav-list__item & {
+      justify-content: space-between;
+      flex-direction: row;
+    }
+
+    .c-nav-list--mobile & {
+      height: functions.header(height);
+      padding: functions.header(nav-link-padding-lateral) / 3 functions.header(nav-link-padding-lateral) / 2;
+    }
+
+    .c-nav-list--desktop & {
+      height: functions.header(height);
+      padding: functions.header(nav-link-padding-lateral);
+    }
+
+    .c-sub-subnav-list__item-inner > & {
+      color: #333;
+      background-color: $_button-bg-color;
+
+      &:hover,
+      &:focus-visible,
+      &--is-active {
+        color: functions.palette(white);
+        background-color: functions.palette(turquoise50);
+      }
+
+      .c-nav-list--mobile & {
+        padding: functions.header(nav-link-padding-lateral) / 2 functions.header(nav-link-padding-lateral);
+      }
+    }
+
+    &-icon {
+      width: 24px;
+      height: 24px;
+      transform: rotate(-90deg);
+    }
+
+    &-text {
+      max-width: calc(100% - 34px);
+      text-align: left;
+    }
+
+    &--is-active &-icon {
+      transform: rotate(90deg);
+    }
+  }
+}

--- a/components/global/Header/index.js
+++ b/components/global/Header/index.js
@@ -25,7 +25,7 @@ import SRAuthStatus from "../../auth/SRAuthStatus";
 
 export default function Header({ navItems, userProfilePage }) {
   const [mobileNavActive, setMobileNavActive] = useState(false);
-  const [isOpen, setIsOpen] = useState(false);
+  const [desktopNavActive, setDesktopNavActive] = useState(false);
   const [mobileLogoActive, setMobileLogoActive] = useState(false);
   const [prevScrollPos, setPrevScrollPos] = useState(0);
   const [visible, setVisible] = useState(true);
@@ -57,7 +57,7 @@ export default function Header({ navItems, userProfilePage }) {
     <header
       ref={ref}
       className={`c-global-header ${
-        visible || mobileNavActive || isOpen ? "" : "invisible"
+        visible || mobileNavActive || desktopNavActive ? "" : "invisible"
       }`}
     >
       <a href="#page-content" className="c-global-header__skip-link">
@@ -79,7 +79,11 @@ export default function Header({ navItems, userProfilePage }) {
         </Link>
       </div>
       <nav className="c-global-header__nav-block">
-        <Navigation items={navItems} theme="desktop" isOpenSetter={setIsOpen} />
+        <Navigation
+          items={navItems}
+          theme="desktop"
+          desktopSetter={setDesktopNavActive}
+        />
       </nav>
       <div className="c-global-header__search-block">
         <SearchBar />

--- a/components/global/Header/index.js
+++ b/components/global/Header/index.js
@@ -25,6 +25,7 @@ import SRAuthStatus from "../../auth/SRAuthStatus";
 
 export default function Header({ navItems, userProfilePage }) {
   const [mobileNavActive, setMobileNavActive] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
   const [mobileLogoActive, setMobileLogoActive] = useState(false);
   const [prevScrollPos, setPrevScrollPos] = useState(0);
   const [visible, setVisible] = useState(true);
@@ -56,7 +57,7 @@ export default function Header({ navItems, userProfilePage }) {
     <header
       ref={ref}
       className={`c-global-header ${
-        visible || mobileNavActive ? "" : "invisible"
+        visible || mobileNavActive || isOpen ? "" : "invisible"
       }`}
     >
       <a href="#page-content" className="c-global-header__skip-link">
@@ -78,7 +79,7 @@ export default function Header({ navItems, userProfilePage }) {
         </Link>
       </div>
       <nav className="c-global-header__nav-block">
-        <Navigation items={navItems} theme="desktop" />
+        <Navigation items={navItems} theme="desktop" isOpenSetter={setIsOpen} />
       </nav>
       <div className="c-global-header__search-block">
         <SearchBar />

--- a/lib/api/fragments/global.js
+++ b/lib/api/fragments/global.js
@@ -5,10 +5,15 @@ fragment pageTreeFragment on EntryInterface {
   id
   title
   uri
-  children(type: ["not", "educatorPages"]) {
+  children(isVisible: true) {
     id
     title
     uri
+    children(isVisible: true) {
+      id
+      title
+      uri
+    }
   }
 }
 `;

--- a/lib/api/global.js
+++ b/lib/api/global.js
@@ -26,7 +26,7 @@ export async function getGlobalData() {
         section: "pages"
         site: "default"
         level: 1
-        type: ["not", "educatorPages"]
+        isVisible: true
       ) {
         ...pageTreeFragment
       }
@@ -46,7 +46,7 @@ export async function getGlobalData() {
         section: "pages"
         site: "es"
         level: 1
-        type: ["not", "educatorPages"]
+        isVisible: true
       ) {
         ...pageTreeFragment
       }
@@ -81,7 +81,7 @@ export function useGlobalData() {
           section: "pages"
           site: "default"
           level: 1
-          type: ["not", "educatorPages"]
+          isVisible: true
         ) {
           ...pageTreeFragment
         }
@@ -96,7 +96,7 @@ export function useGlobalData() {
           section: "pages"
           site: "es"
           level: 1
-          type: ["not", "educatorPages"]
+          isVisible: true
         ) {
           ...pageTreeFragment
         }

--- a/theme/styles/abstracts/_variables.scss
+++ b/theme/styles/abstracts/_variables.scss
@@ -66,9 +66,9 @@ $header: (
   gap: 0,
   layout-breakpoint: 1625px,
   breakpoint-for-search-bar: 850px,
-  nav-link-padding-lateral: 0.8em,
-  nav-width-desktop: 300px,
-  nav-width-mobile: 225px,
+  nav-link-padding-lateral: 1em,
+  nav-width-desktop: 600px,
+  nav-width-mobile: 300px,
   button-width-tablet: 114px,
   button-width-mobile: 60px,
 );

--- a/theme/styles/abstracts/_variables.scss
+++ b/theme/styles/abstracts/_variables.scss
@@ -67,7 +67,7 @@ $header: (
   layout-breakpoint: 1625px,
   breakpoint-for-search-bar: 850px,
   nav-link-padding-lateral: 1em,
-  nav-width-desktop: 600px,
+  nav-width-desktop: 450px,
   nav-width-mobile: 300px,
   button-width-tablet: 114px,
   button-width-mobile: 60px,

--- a/theme/styles/components/_index.scss
+++ b/theme/styles/components/_index.scss
@@ -5,6 +5,7 @@
 @forward "components/global/Header/header";
 @forward "components/global/Header/navigation.scss";
 @forward "components/global/Header/subnavigation.scss";
+@forward "components/global/Header/subsubnavigation.scss";
 @forward "components/global/Header/search-bar.scss";
 @forward "components/global/Footer/footer";
 @forward "components/global/Footer/social.scss";

--- a/theme/styles/globalStyles.js
+++ b/theme/styles/globalStyles.js
@@ -42,7 +42,6 @@ export const tokens = {
   red20: "#f2c3c0",
   red40: "#FF8489",
   BREAK_HEADER_LAYOUT: "1625px",
-  BREAK_HEADER_LAYOUT: "1500px",
   BREAK_DESKTOP: "1280px",
   BREAK_DESKTOP_SMALL: "1130px",
   BREAK_LARGE_TABLET: "850px",


### PR DESCRIPTION
Must test with https://github.com/lsst-epo/rubin-obs-api/pull/224

Introduces a sense of a 3rd level to the Header Nav.  Design is not quite consistent with Jose's original vision as implementing a non-accordion 3rd level in the desktop nav proved to be much more involved than anticipated.  Could circle back on that in the future, but was eager to release this work as-is so that Kristen and Steph may begin reorganizing the pagetree ASAP.  In addition to new styles and functionality to support a 3rd level, there are also many small stylistic updates to the header and the nav in general (all as seen in Jose's latest design).

### What to Test
On Desktop:
- If a nav drop down is open it should remain open, and the header should remain visible on scroll

On mobile:
- If a mobile nav is open it should remain open, and the header should remain visible on scroll

On Both
- If 2nd or 3rd level nav items are visible, they should be hidden after you switch to another set of 2nd or 3rd level nav items
- If you switch language nav should close
- Nav should visually match (approximately) design, with the exception that we use the mobile accordion style for 3rd level nav items on mobile and desktop