### PR TITLE
[F] Embed Content Block can have url or html

### DIFF
--- a/components/content-blocks/Embed/index.js
+++ b/components/content-blocks/Embed/index.js
@@ -3,30 +3,27 @@ import styled from "styled-components";
 import { containerFullBleed } from "@/styles/globalStyles";
 import { Container } from "@rubin-epo/epo-react-lib";
 
-export default function Embed(props) {
-  const {
-    embedTitle,
-    fullWidth,
-    embed: { url },
-  } = props;
-
+export default function Embed({ embedTitle, fullWidth, embedCode, embedUrl }) {
   const EmbedContainer = fullWidth ? FullWidth : Container;
 
   return (
     <EmbedContainer>
       <HeightHack>
-        <StyledEmbed
-          className="iframe"
-          width="100%"
-          scrolling="no"
-          allowtransparency="true"
-          frameBorder="0"
-          marginWidth="0"
-          title={embedTitle}
-          allowFullScreen="allowfullscreen"
-          marginHeight="0"
-          src={url}
-        />
+        {embedCode ? (
+          <StyledEmbedWrapper dangerouslySetInnerHTML={{ __html: embedCode }} />
+        ) : (
+          <StyledEmbed
+            className="iframe"
+            width="100%"
+            allowtransparency="true"
+            frameBorder="0"
+            marginWidth="0"
+            title={embedTitle}
+            allowFullScreen="allowfullscreen"
+            marginHeight="0"
+            src={embedUrl}
+          />
+        )}
       </HeightHack>
     </EmbedContainer>
   );
@@ -47,13 +44,26 @@ const StyledEmbed = styled.iframe`
   top: 0;
   left: 0;
   width: 100%;
-  height: 100vh;
+  height: 100%;
+  max-height: 100vh;
+`;
+
+const StyledEmbedWrapper = styled.div`
+  iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    max-height: 100vh;
+  }
 `;
 
 Embed.displayName = "ContentBlock.Text";
 
 Embed.propTypes = {
-  embed: PropTypes.object,
+  embedCode: PropTypes.string,
+  embedUrl: PropTypes.string,
   fullWidth: PropTypes.bool,
   embedTitle: PropTypes.string,
 };

--- a/lib/api/fragments/content-blocks.js
+++ b/lib/api/fragments/content-blocks.js
@@ -576,9 +576,8 @@ export const embedBlockFragment = `
       typeHandle
       embedTitle
       fullWidth
-      embed {
-        url
-      }
+      embedCode
+      embedUrl: externalUrl
     } 
   }
 `;


### PR DESCRIPTION
N.B.  This replaces the previous implementation of an iframe content block.  The previous iteration used a Craft Plugin called [oembed](https://github.com/wrav/oembed) which has proved fairly finicky, so pivoting to a more pared down approach that requires no craft plugin.

****Related to**
https://github.com/lsst-epo/rubin-obs-api/pull/233

**What it Does**
Updates the Embed Content Block to ditch the oembed Craft plugin constraints, and use either a `url` as the iframe's src, or actual `html` to dangerously inject into the DOM.

**How to Test**
1. Add an Embed Content Block to a page
2. Add an Embed Url.  Try [a google calendar](https://calendar.google.com/calendar/embed?src=c_55d0f7f415d1066af680dc21c3bba15ea882d3fe9860b0f60cdc70ce7a528d19%40group.calendar.google.com&ctz=America%2FLos_Angeles), [a google spreadsheet](https://docs.google.com/spreadsheets/d/18iX9OL4qTVzu7ib68G-0g-bCk15tcjpXdw-uc7sZ-fE/edit?usp=sharing), and [a lsst.io glossary](https://lsst-texmf.lsst.io/glossary.html)
3. Save page entry and view on the frontend.  Expect the iframe to render and be the StyledEmbed component.
4. Observe the iframe scrolls if it's taller than 100vh
5. Go back to the Embed Content Block in the page entry and add an Embed Codde (should be some html with an iframe but hypothetically can be whatever) and view on the frontend.  Expect iframe to render wrapped in a StyledEmbedWrapper component.
6. Observe the iframe scrolls if it's taller than 100vh