### PR TITLE
[C] update React

### DIFF
--- a/components/global/Header/Navigation.js
+++ b/components/global/Header/Navigation.js
@@ -12,7 +12,7 @@ import NavItemWithChildren from "./NavItemWithChildren";
 export default function Navigation({
   items,
   userProfilePage,
-  theme,
+  theme = "desktop",
   desktopSetter,
   mobileActive,
   mobileSetter,
@@ -166,8 +166,4 @@ Navigation.propTypes = {
   desktopSetter: PropTypes.func,
   mobileActive: PropTypes.bool,
   mobileSetter: PropTypes.func,
-};
-
-Navigation.defaultProps = {
-  theme: "desktop",
 };

--- a/components/page/Breadcrumbs/index.js
+++ b/components/page/Breadcrumbs/index.js
@@ -1,5 +1,4 @@
 import PropTypes from "prop-types";
-import Link from "next/link";
 import internalLinkShape from "@/shapes/link";
 import * as Styled from "./styles";
 
@@ -8,11 +7,13 @@ export default function Breadcrumbs({ breadcrumbs, type }) {
 
   return (
     <Styled.Breadcrumbs breadcrumbs={breadcrumbs} $type={type}>
-      {({ id, uri, title, ...restProps }) => (
-        <Link legacyBehavior prefetch={false} href={`/${uri}`} passHref>
-          <Styled.Link {...restProps}>{title}</Styled.Link>
-        </Link>
-      )}
+      {({ id, uri, title, ...restProps }) => {
+        return (
+          <Styled.Link prefetch={false} href={`/${uri}`} {...restProps}>
+            {title}
+          </Styled.Link>
+        );
+      }}
     </Styled.Breadcrumbs>
   );
 }

--- a/components/page/Breadcrumbs/styles.js
+++ b/components/page/Breadcrumbs/styles.js
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import BaseLink from "next/link";
 import CommonJsBreadcrumbs from "@castiron/components-breadcrumbs";
 import { containerRegular, respond, tokens } from "@/styles/globalStyles";
 
@@ -66,7 +67,7 @@ export const Breadcrumbs = styled(BreadcrumbsWrapper)`
   }
 `;
 
-export const Link = styled.a`
+export const Link = styled(BaseLink)`
   display: block;
   padding-right: 1em;
   padding-left: 1em;

--- a/components/templates/EventPage/index.js
+++ b/components/templates/EventPage/index.js
@@ -52,7 +52,6 @@ export default function EventPage({
     id,
     uri,
     title,
-    active: true,
   };
   // logic for displaying city/state in US, city/country outside
   const location = `${address ? address + "," : ""} ${createLocationString(

--- a/components/templates/GalleryPage/index.js
+++ b/components/templates/GalleryPage/index.js
@@ -82,7 +82,6 @@ export default function GalleryPage({
     id,
     uri,
     title,
-    active: true,
   };
 
   const image = featuredImage[0];

--- a/components/templates/GlossaryPage/index.js
+++ b/components/templates/GlossaryPage/index.js
@@ -33,7 +33,6 @@ export default function GlossaryPage({ data }) {
     id,
     uri,
     title,
-    active: true,
   };
 
   return (

--- a/components/templates/NewsPage/index.js
+++ b/components/templates/NewsPage/index.js
@@ -48,7 +48,6 @@ export default function NewsPage({ data }) {
     id,
     uri,
     title,
-    active: true,
   };
   const manualAssets = [];
   const heroBlock =

--- a/components/templates/Page/index.js
+++ b/components/templates/Page/index.js
@@ -60,7 +60,6 @@ export default function Page({
     id,
     uri,
     title,
-    active: true,
   };
 
   // add FilterBar to dynamic pages

--- a/components/templates/SearchPage/index.js
+++ b/components/templates/SearchPage/index.js
@@ -21,7 +21,6 @@ export default function SearchPage({
     id,
     uri,
     title,
-    active: true,
   };
   const { query } = usePathData();
   const keyphrase =

--- a/components/templates/SlideshowPage/index.js
+++ b/components/templates/SlideshowPage/index.js
@@ -32,7 +32,6 @@ export default function SlideshowPage({
     id,
     uri,
     title,
-    active: true,
   };
 
   // prepend main slide to content slides

--- a/components/templates/StaffPage/index.js
+++ b/components/templates/StaffPage/index.js
@@ -50,7 +50,6 @@ export default function StaffPage({
     id,
     uri,
     title,
-    active: true,
   };
   const breadcrumbs = [parentEntry, pageLink].filter(Boolean);
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "**/styles.js": "yarn fix:styled"
   },
   "dependencies": {
-    "@castiron/components-breadcrumbs": "^1.1.0",
+    "@castiron/components-breadcrumbs": "2.0.2",
     "@castiron/style-mixins": "^1.0.6",
     "@headlessui/react": "^1.6.6",
     "@influxdata/influxdb-client": "^1.33.2",
@@ -78,8 +78,8 @@
     "next": "^14.2.3",
     "next-build-id": "^3.0.0",
     "npm-run-all": "^4.1.5",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "react-hook-form": "^7.33.1",
     "react-i18next": "^12.0.0",
     "react-is": "^18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1307,13 +1307,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@castiron/components-breadcrumbs@^1.1.0":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@castiron/components-breadcrumbs/-/components-breadcrumbs-1.1.1.tgz#47b807fcbde70a4b97df86f420a9cc87dfae2dc2"
-  integrity sha512-Co/ekL48nalttIAY262CgLFtr1hI4KJ0XZsoT/FQEbMag7zKlkKgK9u5gOK9Vi14u7I9WYb1fziERl2Sw8LYeg==
-  dependencies:
-    react "^17.0.1"
-    react-dom "^17.0.1"
+"@castiron/components-breadcrumbs@2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@castiron/components-breadcrumbs/-/components-breadcrumbs-2.0.2.tgz#62f4298090bc35cca2832e582e2f97f75e347459"
+  integrity sha512-VrKD3qvlGU4erPoGQ1Dj50KzLFEyDKvD+VsxTAie/yjI/HR5n3x2ipRjuKqslmZHp6D8vbmZJXmvzQBySVlpCA==
 
 "@castiron/style-mixins@^1.0.6":
   version "1.0.7"
@@ -9422,22 +9419,13 @@ react-docgen@^5.0.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-react-dom@18.2.0:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
-  integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
+react-dom@^18.3.1:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.3.1.tgz#c2265d79511b57d479b3dd3fdfa51536494c5cb4"
+  integrity sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==
   dependencies:
     loose-envify "^1.1.0"
-    scheduler "^0.23.0"
-
-react-dom@^17.0.1:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
-  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    scheduler "^0.20.2"
+    scheduler "^0.23.2"
 
 react-element-to-jsx-string@^15.0.0:
   version "15.0.0"
@@ -9539,20 +9527,12 @@ react-uid@^2.3.2:
   dependencies:
     tslib "^2.0.0"
 
-react@18.2.0:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
-  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
+react@^18.3.1:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.3.1.tgz#49ab892009c53933625bd16b2533fc754cab2891"
+  integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==
   dependencies:
     loose-envify "^1.1.0"
-
-react@^17.0.1:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
-  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 read-pkg-up@^7.0.1:
   version "7.0.1"
@@ -9982,18 +9962,10 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-scheduler@^0.20.2:
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
-  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-
-scheduler@^0.23.0:
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
-  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
+scheduler@^0.23.2:
+  version "0.23.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.2.tgz#414ba64a3b282892e944cf2108ecc078d115cdc3"
+  integrity sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==
   dependencies:
     loose-envify "^1.1.0"
 


### PR DESCRIPTION
Resolves #459 

Update React to 18.3 to prepare for React 19. Upgrade includes:

- Remove deprecated `defaultProps` from `Navigation` and replace with destructuring defaults
- Upgrade `@castiron/components-breadcrumbs` to remove incorrect dependency on `react-dom@17`
   - Remove `active: true` from breadcrumbs that prompts an invalid attribute error
   - Replace legacy `Link` setup on breadcrumb links.