### PR TITLE
[F] events pages can be filtered by server

### DIFF
--- a/components/page/FilterBar/index.js
+++ b/components/page/FilterBar/index.js
@@ -1,31 +1,19 @@
 import { useRef, useState, useCallback } from "react";
-import { useRouter } from "next/router";
 import PropTypes from "prop-types";
-import styled from "styled-components";
-import {
-  fluidScale,
-  BREAK_MOBILE,
-  containerRegular,
-  respond,
-} from "@/styles/globalStyles";
 import { useTranslation } from "react-i18next";
 import { MixedLink, IconComposer } from "@rubin-epo/epo-react-lib";
 import T from "@/page/Translate";
 import { useOnClickOutside } from "@/hooks/listeners";
-import {
-  usePathData,
-  normalizePathData,
-  getCategoryGroup,
-  useGlobalData,
-} from "@/lib/utils";
+import { usePathData, getCategoryGroup, useGlobalData } from "@/lib/utils";
 import withLiveRegionChange from "@/hoc/withLiveRegionChange";
+import { useFilterParams } from "@/contexts/FilterParams";
+import * as Styled from "./styles";
 
 const FilterBar = ({ filterType, setLiveRegionMessage }) => {
+  const { params, hidden, setParams, resetParams } = useFilterParams();
   const { t } = useTranslation();
   const ref = useRef();
-  const { asPath, query } = usePathData();
-  const { pathname, pathParams } = normalizePathData(asPath);
-  delete query.uriSegments;
+  const { asPath } = usePathData();
   const { categories } = useGlobalData();
   const filterMap = {
     events: "eventFilters",
@@ -37,10 +25,12 @@ const FilterBar = ({ filterType, setLiveRegionMessage }) => {
   };
   const filterItems = getCategoryGroup(categories, filterMap[filterType]);
   const sortItems = getCategoryGroup(categories, "sortOptions");
-  const router = useRouter();
-  const [searchText, setSearchText] = useState(query.search || "");
+  const [searchText, setSearchText] = useState(params.search || "");
   const [filterOpen, setFilterOpen] = useState(false);
   const [sortOpen, setSortOpen] = useState(false);
+  const hasFilter = !hidden.includes("filter") && !!filterItems?.length;
+  const hasSort = !hidden.includes("sort");
+  const hasSearch = !hidden.includes("search");
 
   useOnClickOutside(ref, () => {
     setFilterOpen(false);
@@ -63,39 +53,36 @@ const FilterBar = ({ filterType, setLiveRegionMessage }) => {
 
   const handleSubmit = (event) => {
     event.preventDefault();
-    router.push({
-      pathname,
-      query: { ...pathParams, page: 1, search: searchText },
-    });
+    setParams({ page: 1, search: searchText });
   };
 
   const handleReset = () => {
     setSearchText("");
     setLiveRegionMessage("Search cleared.");
-    router.push(pathname);
+    resetParams();
   };
 
   return (
-    <FilterNav ref={ref} aria-label={`${filterType} search tools`}>
-      <FilterGrid>
-        {!!filterItems?.length && (
+    <Styled.FilterNav ref={ref} aria-label={`${filterType} search tools`}>
+      <Styled.FilterGrid>
+        {hasFilter && (
           <div>
-            <ToggleButton
+            <Styled.ToggleButton
               onClick={handleFilter}
               aria-expanded={filterOpen}
               aria-controls="filter-dropdown"
             >
-              <div></div>
+              <Styled.ToggleIcon />
               <span>Filter</span>
-            </ToggleButton>
-            <ToggleDropdown id="filter-dropdown" opened={filterOpen}>
+            </Styled.ToggleButton>
+            <Styled.ToggleDropdown id="filter-dropdown" opened={filterOpen}>
               <li>
                 <MixedLink url={asPath} params={{ filter: "" }}>
                   <T i18nKey={`filters.all`} />
                 </MixedLink>
               </li>
               {filterItems.map((item, i) => {
-                const active = query?.filter?.includes(item.id);
+                const active = params?.filter?.includes(item.id);
 
                 return (
                   <li key={i}>
@@ -109,234 +96,64 @@ const FilterBar = ({ filterType, setLiveRegionMessage }) => {
                   </li>
                 );
               })}
-            </ToggleDropdown>
+            </Styled.ToggleDropdown>
           </div>
         )}
-        <div>
-          <ToggleButton
-            onClick={handleSort}
-            aria-expanded={sortOpen}
-            aria-controls="sort-dropdown"
-          >
-            <div id="sort"></div>
-            <span>{t(`filters.sort`)}</span>
-          </ToggleButton>
-          <ToggleDropdown id="sort-dropdown" opened={sortOpen}>
-            {sortItems.map((item, i) => {
-              const active = query?.sort?.includes(item.slug);
+        {hasSort && (
+          <div>
+            <Styled.ToggleButton
+              onClick={handleSort}
+              aria-expanded={sortOpen}
+              aria-controls="sort-dropdown"
+            >
+              <Styled.SortToggleIcon id="sort" />
+              <span>{t(`filters.sort`)}</span>
+            </Styled.ToggleButton>
+            <Styled.ToggleDropdown id="sort-dropdown" opened={sortOpen}>
+              {sortItems.map((item, i) => {
+                const active = params?.sort?.includes(item.slug);
 
-              return (
-                <li key={i}>
-                  <MixedLink
-                    className={active ? "active" : ""}
-                    url={asPath}
-                    params={{ sort: item.slug }}
-                  >
-                    {item.title}
-                  </MixedLink>
-                </li>
-              );
-            })}
-          </ToggleDropdown>
-        </div>
-        <FilterSearch onSubmit={handleSubmit}>
-          <button type="submit">
-            <IconComposer icon="search" />
-            <span className="a-hidden">{t("submit-search")}</span>
-          </button>
-          <label htmlFor="filterSearchInput" className="a-hidden">
-            {t("search-filter")}
-          </label>
-          <input
-            id="filterSearchInput"
-            type="search"
-            placeholder={t("search-filter-placeholder")}
-            value={searchText}
-            onChange={(e) => handleChange(e.target.value)}
-          />
-        </FilterSearch>
-        <Clear onClick={handleReset}>
+                return (
+                  <li key={i}>
+                    <MixedLink
+                      className={active ? "active" : ""}
+                      url={asPath}
+                      params={{ sort: item.slug }}
+                    >
+                      {item.title}
+                    </MixedLink>
+                  </li>
+                );
+              })}
+            </Styled.ToggleDropdown>
+          </div>
+        )}
+        {hasSearch && (
+          <Styled.FilterSearch onSubmit={handleSubmit}>
+            <button type="submit">
+              <IconComposer icon="search" />
+              <span className="a-hidden">{t("submit-search")}</span>
+            </button>
+            <label htmlFor="filterSearchInput" className="a-hidden">
+              {t("search-filter")}
+            </label>
+            <input
+              id="filterSearchInput"
+              type="search"
+              placeholder={t("search-filter-placeholder")}
+              value={searchText}
+              onChange={(e) => handleChange(e.target.value)}
+            />
+          </Styled.FilterSearch>
+        )}
+        <Styled.Clear onClick={handleReset}>
           <IconComposer icon="cancel" />
           {t(`search-clear`)}
-        </Clear>
-      </FilterGrid>
-    </FilterNav>
+        </Styled.Clear>
+      </Styled.FilterGrid>
+    </Styled.FilterNav>
   );
 };
-
-const FilterNav = styled.nav`
-  font-size: 16px;
-  font-weight: bold;
-  color: var(--neutral80);
-  background-color: var(--neutral20);
-  padding: 12px 0;
-`;
-
-const FilterGrid = styled.div`
-  ${containerRegular()}
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 20px;
-
-  > * {
-    position: relative;
-    flex: 0 1 180px;
-  }
-
-  @media (max-width: 720px) {
-    flex-wrap: wrap;
-
-    > * {
-      flex-basis: calc(33.333% - 20px);
-    }
-  }
-`;
-
-const ToggleButton = styled.button`
-  position: relative;
-  height: 30px;
-  white-space: nowrap;
-
-  > div {
-    position: absolute;
-    top: 50%;
-    left: 0;
-    display: block;
-    width: 30px;
-    height: 4px;
-    margin-top: -0.1em;
-    background-color: var(--neutral80);
-
-    &:after,
-    &:before {
-      position: absolute;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      content: "";
-      background-color: var(--neutral80);
-    }
-
-    &:before {
-      transform: translateY(-9px);
-    }
-
-    &:after {
-      transform: translateY(9px);
-    }
-
-    &#sort {
-      left: 5px;
-      width: 20px;
-
-      &:before {
-        left: -5px;
-        width: 30px;
-      }
-
-      &:after {
-        left: 5px;
-        width: 10px;
-      }
-    }
-  }
-  > span {
-    padding-left: 50px;
-  }
-  ${respond(`div {display: none;} span {padding-left: 0;}`, BREAK_MOBILE)}
-`;
-
-const ToggleDropdown = styled.ul`
-  position: absolute;
-  top: 40px;
-  opacity: ${(p) => (p.opened ? 1 : 0)};
-  visibility: ${(p) => (p.opened ? "visible" : "hidden")};
-  width: 300px;
-  background-color: var(--neutral20);
-  transition: opacity 0.2s;
-  z-index: ${(p) => (p.opened ? 1 : -1)};
-  ${respond(`width: auto;`, "640px")}
-
-  li {
-    a {
-      display: block;
-      padding: 10px 20px;
-      font-weight: normal;
-      text-decoration: none;
-
-      &:hover,
-      &.active {
-        background-color: var(--turquoise50);
-        font-weight: bold;
-        color: white;
-      }
-    }
-
-    &:first-of-type {
-      margin-top: 20px;
-    }
-  }
-`;
-
-const FilterSearch = styled.form`
-  flex-grow: 1;
-  text-align: right;
-  white-space: nowrap;
-
-  button {
-    padding: 4px 5px 4px 15px;
-    height: 50px;
-    vertical-align: middle;
-    border-radius: 25px 0 0 25px;
-    background-color: white;
-
-    svg {
-      width: 14px;
-      height: 14px;
-    }
-  }
-
-  input {
-    border: none;
-    width: ${fluidScale("480px", "200px")};
-    height: 50px;
-    padding: 4px 6px 5px 6px;
-    vertical-align: middle;
-    border-radius: 0 25px 25px 0;
-    color: var(--neutral80);
-    background-color: white;
-  }
-
-  @media screen and (max-width: 720px) {
-    flex-basis: 100%;
-    order: -1;
-    text-align: start;
-
-    input {
-      width: calc(100% - 34px);
-    }
-  }
-`;
-
-const Clear = styled.button`
-  display: grid;
-  grid-auto-flow: column;
-  place-content: center;
-  margin-left: 0.5em;
-  padding: 0.5em 1.5em;
-  white-space: nowrap;
-  height: 50px;
-  border-radius: 25px;
-  background-color: var(--neutral30);
-  &:hover {
-    background-color: var(--red20);
-  }
-  svg {
-    margin-right: 4px;
-  }
-`;
 
 FilterBar.propTypes = {
   filterType: PropTypes.string,

--- a/components/page/FilterBar/styles.js
+++ b/components/page/FilterBar/styles.js
@@ -1,0 +1,184 @@
+import styled from "styled-components";
+import {
+  fluidScale,
+  BREAK_MOBILE,
+  containerRegular,
+  respond,
+} from "@/styles/globalStyles";
+
+export const FilterNav = styled.nav`
+  padding: 12px 0;
+  font-size: 16px;
+  font-weight: bold;
+  color: var(--neutral80);
+  background-color: var(--neutral20);
+`;
+
+export const FilterGrid = styled.div`
+  ${containerRegular()}
+  position: relative;
+  display: flex;
+  gap: 20px;
+  align-items: center;
+  justify-content: flex-start;
+
+  > * {
+    position: relative;
+    flex: 0 1 180px;
+  }
+
+  @media (max-width: 720px) {
+    flex-wrap: wrap;
+
+    > * {
+      flex-basis: calc(33.333% - 20px);
+    }
+  }
+`;
+
+export const ToggleButton = styled.button`
+  position: relative;
+  height: 30px;
+  white-space: nowrap;
+
+  > span {
+    padding-left: 50px;
+  }
+  ${respond(`div {display: none;} span {padding-left: 0;}`, BREAK_MOBILE)}
+`;
+
+export const ToggleIcon = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 0;
+  display: block;
+  width: 30px;
+  height: 4px;
+  margin-top: -0.1em;
+  background-color: var(--neutral80);
+
+  &::after,
+  &::before {
+    position: absolute;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    content: "";
+    background-color: var(--neutral80);
+  }
+
+  &::before {
+    transform: translateY(-9px);
+  }
+
+  &::after {
+    transform: translateY(9px);
+  }
+`;
+
+export const SortToggleIcon = styled(ToggleIcon)`
+  left: 5px;
+  width: 20px;
+
+  &::before {
+    left: -5px;
+    width: 30px;
+  }
+
+  &::after {
+    left: 5px;
+    width: 10px;
+  }
+`;
+
+export const ToggleDropdown = styled.ul`
+  position: absolute;
+  top: 40px;
+  z-index: ${(p) => (p.opened ? 1 : -1)};
+  width: 300px;
+  visibility: ${(p) => (p.opened ? "visible" : "hidden")};
+  background-color: var(--neutral20);
+  opacity: ${(p) => (p.opened ? 1 : 0)};
+  transition: opacity 0.2s;
+  ${respond(`width: auto;`, "640px")}
+
+  li {
+    a {
+      display: block;
+      padding: 10px 20px;
+      font-weight: normal;
+      text-decoration: none;
+
+      &:hover,
+      &.active {
+        font-weight: bold;
+        color: white;
+        background-color: var(--turquoise50);
+      }
+    }
+
+    &:first-of-type {
+      margin-top: 20px;
+    }
+  }
+`;
+
+export const FilterSearch = styled.form`
+  flex-grow: 1;
+  text-align: right;
+  white-space: nowrap;
+
+  button {
+    height: 50px;
+    padding: 4px 5px 4px 15px;
+    vertical-align: middle;
+    background-color: white;
+    border-radius: 25px 0 0 25px;
+
+    svg {
+      width: 14px;
+      height: 14px;
+    }
+  }
+
+  input {
+    width: ${fluidScale("480px", "200px")};
+    height: 50px;
+    padding: 4px 6px 5px;
+    color: var(--neutral80);
+    vertical-align: middle;
+    background-color: white;
+    border: none;
+    border-radius: 0 25px 25px 0;
+  }
+
+  @media screen and (max-width: 720px) {
+    flex-basis: 100%;
+    order: -1;
+    text-align: start;
+
+    input {
+      width: calc(100% - 34px);
+    }
+  }
+`;
+
+export const Clear = styled.button`
+  display: grid;
+  grid-auto-flow: column;
+  place-content: center;
+  height: 50px;
+  padding: 0.5em 1.5em;
+  margin-left: 0.5em;
+  white-space: nowrap;
+  background-color: var(--neutral30);
+  border-radius: 25px;
+
+  &:hover {
+    background-color: var(--red20);
+  }
+
+  svg {
+    margin-right: 4px;
+  }
+`;

--- a/components/templates/Page/index.js
+++ b/components/templates/Page/index.js
@@ -19,12 +19,14 @@ import GuideNavigation from "@/components/layout/GuideNavigation";
 import SiblingNavigation from "@/components/layout/SiblingNavigation";
 import NestedContext from "@/contexts/Nested";
 import PageContent from "@/page/PageContent";
+import { FilterParamsProvider } from "@/contexts/FilterParams";
 
 export default function Page({
   data: {
     contentBlocks = [],
     description,
     dynamicComponent,
+    eventFilter = [],
     featuredImage,
     hero,
     focalPointX,
@@ -99,9 +101,12 @@ export default function Page({
     title = t(`gallery.plural-${categoryObj.slug}`);
   }
 
-  const isInvestigationChild = investigation?.landingPage?.[0]?.uri !== uri;
   const showSiblingNav = parent?.children && showGuideNav;
   const shouldOverlapHero = !!hero?.length && overlapHero;
+
+  const serverParams = {
+    filter: [...eventFilter.map(({ id }) => id)],
+  };
 
   return (
     <Body {...bodyProps}>
@@ -133,65 +138,69 @@ export default function Page({
             truncate={50}
           />
         )}
-        {hasFilterbar && <FilterBar filterType={dynamicComponent} />}
-        <PageContent
-          heroImage={!showSiblingNav && hero}
-          overlapHero={showSiblingNav ? false : shouldOverlapHero}
-          {...{ focalPointX, focalPointY }}
-        >
-          <SubHero
-            type={typeHandle}
-            header={subHeroHeader}
-            text={subHeroText}
-            colorScheme={subHeroColorScheme}
-            nested={shouldOverlapHero}
-          />
-          <NestedContext.Provider value={shouldOverlapHero}>
-            {!hideTitle && (
-              <Container
-                bgColor="white"
-                className="c-page-header"
-                width={isWideHeader ? "regular" : "narrow"}
-                paddingSize={isMediumPadding ? "medium" : undefined}
-              >
-                <h1>{title}</h1>
-                {isEventsPage && (
-                  <NavButtons
-                    linkLeft="upcoming"
-                    linkRight="past"
-                    textLeft={t(`events.upcoming`)}
-                    textRight={t(`events.past`)}
-                  />
-                )}
-              </Container>
-            )}
-            {contentBlocks.length > 0 &&
-              [...contentBlocks].map((block) => {
-                if (!block.id || !block.typeHandle) return null;
-                return (
-                  <ContentBlockFactory
-                    key={block.id}
-                    type={block.typeHandle}
-                    data={block}
-                    pageId={id}
-                  />
-                );
-              })}
-            {pageType === "dynamic" && dynamicComponent && (
-              <DynamicComponentFactory
-                componentType={dynamicComponent}
-                pageId={id}
-              />
-            )}
-            {children}
-            {showSiblingNav && (
-              <SiblingNavigation
-                siblings={siblings}
-                parent={investigation ? investigation.landingPage?.[0] : parent}
-              />
-            )}
-          </NestedContext.Provider>
-        </PageContent>
+        <FilterParamsProvider {...{ serverParams }}>
+          {hasFilterbar && <FilterBar filterType={dynamicComponent} />}
+          <PageContent
+            heroImage={!showSiblingNav && hero}
+            overlapHero={showSiblingNav ? false : shouldOverlapHero}
+            {...{ focalPointX, focalPointY }}
+          >
+            <SubHero
+              type={typeHandle}
+              header={subHeroHeader}
+              text={subHeroText}
+              colorScheme={subHeroColorScheme}
+              nested={shouldOverlapHero}
+            />
+            <NestedContext.Provider value={shouldOverlapHero}>
+              {!hideTitle && (
+                <Container
+                  bgColor="white"
+                  className="c-page-header"
+                  width={isWideHeader ? "regular" : "narrow"}
+                  paddingSize={isMediumPadding ? "medium" : undefined}
+                >
+                  <h1>{title}</h1>
+                  {isEventsPage && (
+                    <NavButtons
+                      linkLeft="upcoming"
+                      linkRight="past"
+                      textLeft={t(`events.upcoming`)}
+                      textRight={t(`events.past`)}
+                    />
+                  )}
+                </Container>
+              )}
+              {contentBlocks.length > 0 &&
+                [...contentBlocks].map((block) => {
+                  if (!block.id || !block.typeHandle) return null;
+                  return (
+                    <ContentBlockFactory
+                      key={block.id}
+                      type={block.typeHandle}
+                      data={block}
+                      pageId={id}
+                    />
+                  );
+                })}
+              {pageType === "dynamic" && dynamicComponent && (
+                <DynamicComponentFactory
+                  componentType={dynamicComponent}
+                  pageId={id}
+                />
+              )}
+              {children}
+              {showSiblingNav && (
+                <SiblingNavigation
+                  siblings={siblings}
+                  parent={
+                    investigation ? investigation.landingPage?.[0] : parent
+                  }
+                />
+              )}
+            </NestedContext.Provider>
+          </PageContent>
+        </FilterParamsProvider>
       </AuthorizePage>
     </Body>
   );

--- a/contexts/FilterParams.js
+++ b/contexts/FilterParams.js
@@ -1,0 +1,89 @@
+import { createContext, useCallback, useContext } from "react";
+import PropTypes from "prop-types";
+import { normalizePathData } from "@/lib/utils";
+import { useRouter } from "next/router";
+
+const isParamDefined = (filterValue) => {
+  if (Array.isArray(filterValue)) {
+    return filterValue.length > 0;
+  }
+
+  if (typeof filterValue === "string") {
+    return filterValue.length > 0;
+  }
+
+  return typeof filterValue !== "undefined" && filterValue !== null;
+};
+
+const FilterParamsContext = createContext(null);
+
+/** Provider for managing dynamic page filters either
+ * through the router or internal state. In some cases, like
+ * setting up a specific filtered view, it may be preferred to
+ * hide which filters are applied from the URL.
+ */
+export const FilterParamsProvider = ({ children, serverParams = {} }) => {
+  const { asPath, query, push } = useRouter();
+  delete query.uriSegments;
+
+  const { pathname, pathParams } = normalizePathData(asPath);
+
+  const setParams = useCallback(
+    (params = {}) => {
+      push({
+        pathname,
+        query: { ...pathParams, ...params },
+      });
+    },
+    [pathname, pathParams, push]
+  );
+
+  const resetParams = useCallback(() => {
+    push(pathname);
+  }, [pathname, push]);
+
+  const activeServerParams = Object.keys(serverParams).reduce((prev, key) => {
+    if (isParamDefined(serverParams[key])) {
+      prev[key] = serverParams[key];
+    }
+
+    return prev;
+  }, {});
+
+  return (
+    <FilterParamsContext.Provider
+      value={{
+        params: { ...pathParams, ...activeServerParams },
+        hidden: Object.keys(serverParams).filter(
+          (key) => serverParams[key] && serverParams[key].length > 0
+        ),
+        setParams,
+        resetParams,
+      }}
+    >
+      {children}
+    </FilterParamsContext.Provider>
+  );
+};
+
+FilterParamsProvider.propTypes = {
+  children: PropTypes.node,
+  serverParams: PropTypes.shape({
+    filter: PropTypes.arrayOf(PropTypes.string),
+    page: PropTypes.number,
+    search: PropTypes.string,
+    sort: PropTypes.string,
+    type: PropTypes.string,
+  }),
+};
+
+export const useFilterParams = () => {
+  const context = useContext(FilterParamsContext);
+  const { query } = useRouter();
+
+  if (!context) {
+    return { params: query };
+  }
+
+  return context;
+};

--- a/cypress/e2e/filtering.cy.js
+++ b/cypress/e2e/filtering.cy.js
@@ -1,0 +1,53 @@
+describe("Filtering dynamic data", () => {
+  beforeEach(() => {
+    // Cypress starts out with a blank slate for each test
+    // so we must tell it to visit our website with the `cy.visit()` command.
+    // Since we want to visit the same URL at the start of all our tests,
+    // we include it in our beforeEach function so that it runs before each test
+    cy.visit("/calendar");
+  });
+
+  it("Should show all filtered items", () => {
+    const dropdownId = "filter-dropdown";
+    cy.get(`[aria-controls="${dropdownId}"]`).click();
+    cy.get(`[id="${dropdownId}"]`).should("be.visible");
+    cy.get("a").contains("a", "All").click();
+
+    cy.on("url:changed", (newUrl) => {
+      const url = new URL(newUrl);
+      const params = new URLSearchParams(url.search);
+      expect(params.get("filter")).to.contain("");
+    });
+  });
+  it("Should show selected filter", () => {
+    const dropdownId = "filter-dropdown";
+    const filter = "Education Event";
+
+    cy.get(`[aria-controls="${dropdownId}"]`).click();
+    cy.get(`[id="${dropdownId}"]`).should("be.visible");
+    cy.get("a").contains("a", filter).click();
+
+    cy.on("url:changed", (newUrl) => {
+      const url = new URL(newUrl);
+      const params = new URLSearchParams(url.search);
+
+      cy.get(".pretitle").should("have.text", filter);
+      expect(params.get("filter")).to.contain("60613");
+    });
+  });
+  it("Should change sort order", () => {
+    const dropdownId = "sort-dropdown";
+    const sort = "Ascending";
+
+    cy.get(`[aria-controls="${dropdownId}"]`).click();
+    cy.get(`[id="${dropdownId}"]`).should("be.visible");
+    cy.get("a").contains("a", sort).click();
+
+    cy.on("url:changed", (newUrl) => {
+      const url = new URL(newUrl);
+      const params = new URLSearchParams(url.search);
+
+      expect(params.get("sort")).to.contain(sort.toLowerCase());
+    });
+  });
+});

--- a/lib/api/fragments/page.js
+++ b/lib/api/fragments/page.js
@@ -34,6 +34,9 @@ fragment pageFragmentFull on pages_pages_Entry {
     pageType
     typeHandle
     dynamicComponent
+    eventFilter: eventType {
+        id
+    }
     featuredImage {
       ... on contentImages_Asset {
         ${getImageFields("crop", 800, 600)}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,6 +4,7 @@ import GlobalDataContext from "@/contexts/GlobalData";
 import { useDataList } from "@/api/entries";
 import { useReleases } from "@/lib/api/noirlabReleases";
 import debounce from "lodash/debounce";
+import { useFilterParams } from "@/contexts/FilterParams";
 
 export const getLinearScale = (domain, range, clamp = false) => {
   return (val) => {
@@ -60,6 +61,18 @@ function getOffset(limit, page, showsFeatured) {
   return (pageInt - 1) * limit - 1;
 }
 
+const getListTypeId = (filter, listTypeId) => {
+  if (Array.isArray(filter)) {
+    return filter.map((id) => parseInt(id));
+  }
+
+  if (filter) {
+    return parseInt(filter);
+  }
+
+  return listTypeId;
+};
+
 // DATA HOOKS
 export const useList = ({
   excludeId = null,
@@ -69,20 +82,20 @@ export const useList = ({
   listTypeId = null,
   section,
 }) => {
-  const router = useRouter();
-  const { asPath, query } = router;
+  const { asPath } = useRouter();
+  const { params } = useFilterParams();
   const site = getSiteString(asPath);
-  const adjustedLimit = adjustLimit(limit, query.page, showsFeatured);
-  const offset = getOffset(limit, query.page, showsFeatured);
-  const inReverse = query.sort === "descending";
-  const search = query.search ? `"${query.search}"` : null;
+  const adjustedLimit = adjustLimit(limit, params.page, showsFeatured);
+  const offset = getOffset(limit, params.page, showsFeatured);
+  const inReverse = params.sort === "descending";
+  const search = params.search ? `"${params.search}"` : null;
   const categories = useGlobalData("categories");
   // if the search is sitewide (like '/search' is), our list will filter by section instead of listTypeId
-  if (isSitewideSearch && query.filter) {
-    const curr = getCategoryObject(categories, query.filter);
+  if (isSitewideSearch && params.filter) {
+    const curr = getCategoryObject(categories, params.filter);
     section = curr.slug.replace(/-([a-z])/g, (x, up) => up.toUpperCase()); // make camelCase
   } else if (!isSitewideSearch) {
-    listTypeId = parseInt(query.filter) || listTypeId;
+    listTypeId = getListTypeId(params.filter, listTypeId);
   }
 
   const results = useDataList({
@@ -112,7 +125,7 @@ export const useList = ({
     results.data.currentCategory = listTypeId;
     results.data.offset = offset;
     results.data.limit = adjustedLimit;
-    results.data.page = parseInt(query.page) || 1;
+    results.data.page = parseInt(params.page) || 1;
   }
 
   return results;


### PR DESCRIPTION
Events pages (like `/calendar`) can be pre-filtered by the server to only show specific event types like Science, Education, Press, etc. When a page is pre-filtered by the server, the "Filter" dropdown will not be available and the filters will not show up in the URL parameters.

To accomplish this, control of the URL parameters is removed from `FilterBar` and put into a context that wraps the `FilterBar` and then the display components that use the URL parameters to make GraphQL requests. This context accepts the server filters applied, and merges them with any client-side filters then provides that via a hook.

If the provider is not supplied, the hook will return the URL parameters from the router. 

Additionally an E2E test is supplied that validates the function of the filter/sort dropdowns. 

**Testing**

- Go to a dynamic page in Craft (get the corresponding `ag/event-filters` API branch)
- When the dynamic type is set to "Events" a new field should appear to select event categories
- Tag one or more event categories and save the page
- On the client, view the page and see that:
    - The "Filter" dropdown is not shown
    - No filters are passed into the URL parameters
    - Events are filtered by the selected categories
- On the API, remove the categories and re-save the page
- On the client, view the page and see that:
    - The "Filter" dropdown is shown
    - Filters are stored in the URL parameters
    - Only a single filter is applied when selected from the dropdown