### PR TITLE
[C] set height important on hero images

### DIFF
--- a/components/page/Hero/styles.js
+++ b/components/page/Hero/styles.js
@@ -14,7 +14,8 @@ export const HeroImage = styled(Image)`
     `${$focalPointX}% ${$focalPointY}%;`}
   width: 100%;
 
-  height: 100%;
+  /* stylelint-disable declaration-no-important */
+  height: 100% !important;
   object-fit: cover;
   object-position: var(--Hero-object-position, center);
 `;

--- a/components/templates/NewsPage/styles.js
+++ b/components/templates/NewsPage/styles.js
@@ -48,9 +48,10 @@ export const HeroCaption = styled.div`
 export const HeroImage = styled(Image)`
   --Hero-object-position: ${({ $focalPointX, $focalPointY }) =>
     `${$focalPointX}% ${$focalPointY}%;`}
-  width: 100%;
 
-  height: 100%;
+  width: 100%;
+  /* stylelint-disable declaration-no-important */
+  height: 100% !important;
   object-fit: cover;
   object-position: var(--Hero-object-position, center);
 `;


### PR DESCRIPTION
Add `!important` to hero image height so that even if styled-components renders classes out of order, images will not overflow their hero container and will preserve the `object-fit` and `object-position` attributes.