### PR TITLE
refactor: separate homepage from urisegments

### DIFF
--- a/lib/api/entries.js
+++ b/lib/api/entries.js
@@ -63,20 +63,12 @@ async function getData(ENV) {
       {
         entries(
           site: "*"
-          section: ["pages", "homepage", "searchResults"]
+          section: ["pages", "searchResults"]
           type: ["not", "redirectPage"]
           level: 1
         ) {
           uri
           level
-          siteHandle
-        }
-        homepage: entries(
-          site: "*"
-          section: ["homepage"]
-          type: ["not", "redirectPage"]
-        ) {
-          uri
           siteHandle
         }
         search: entries(
@@ -90,13 +82,13 @@ async function getData(ENV) {
       }
     `;
     const res = await queryAPI(query);
-    data.entries = [...res.entries, ...res.homepage, ...res.search];
+    data.entries = [...res.entries, ...res.search];
   } else {
     const query = gql`
       {
         entries(
           site: "*"
-          section: ["pages", "homepage", "searchResults"]
+          section: ["pages", "searchResults"]
           type: ["not", "redirectPage"]
         ) {
           uri

--- a/lib/api/global.js
+++ b/lib/api/global.js
@@ -10,7 +10,8 @@ import {
 } from "@/lib/api/fragments/global";
 import { categoriesFragment } from "@/lib/api/fragments/categories";
 import { userProfileFragment } from "@/lib/api/fragments/page";
-export async function getGlobalData() {
+
+export async function getGlobalData(site = "default") {
   const query = gql`
     ${linkFragment}
     ${siteInfoFragment}
@@ -19,10 +20,10 @@ export async function getGlobalData() {
     ${contactFormFragment}
     ${categoriesFragment}
     ${userProfileFragment}
-    {
+    query getGlobalData($site: [String]) {
       pageTree: entries(
         section: "pages"
-        site: "default"
+        site: $site
         level: 1
         isVisible: true
       ) {
@@ -40,53 +41,21 @@ export async function getGlobalData() {
           }
         }
       }
-      globals: globalSets(site: "default") {
+      globals: globalSets(site: $site) {
         ...rootPageInfoFragment
         ...siteInfoFragment
         ...footerFragment
         ...contactFormFragment
       }
-      allCategories: categories(site: "default") {
+      allCategories: categories(site: $site) {
         ...categoriesFragment
       }
-      userProfilePage: entry(site: "default", type: "userProfilePage") {
-        ...userProfileFragment
-      }
-      pageTree_es: entries(
-        section: "pages"
-        site: "es"
-        level: 1
-        isVisible: true
-      ) {
-        id
-        title
-        uri
-        children(isVisible: true) {
-          id
-          title
-          uri
-          children(isVisible: true) {
-            id
-            title
-            uri
-          }
-        }
-      }
-      globals_es: globalSets(site: "es") {
-        ...rootPageInfoFragment
-        ...siteInfoFragment
-        ...footerFragment
-        ...contactFormFragment
-      }
-      allCategories_es: categories(site: "es") {
-        ...categoriesFragment
-      }
-      userProfilePage_es: entry(site: "es", type: "userProfilePage") {
+      userProfilePage: entry(site: $site, type: "userProfilePage") {
         ...userProfileFragment
       }
     }
   `;
-  const data = await queryAPI(query);
+  const data = await queryAPI(query, undefined, undefined, { site });
   return data;
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -420,6 +420,10 @@ export function getSiteString(langData = "", asLangString = false) {
   }
 }
 
+/**
+ * @function getSiteFromLocale
+ * @param {string} locale
+ */
 export const getSiteFromLocale = (locale) => {
   return locale.includes("en") ? "default" : "es";
 };

--- a/pages/[locale]/index.js
+++ b/pages/[locale]/index.js
@@ -21,7 +21,7 @@ export function getStaticPaths() {
     paths: languages.map((language) => {
       return { params: { locale: language } };
     }),
-    fallback: "blocking",
+    fallback: false,
   };
 }
 

--- a/pages/[locale]/index.js
+++ b/pages/[locale]/index.js
@@ -1,0 +1,137 @@
+import PropTypes from "prop-types";
+import { GoogleOAuthProvider } from "@react-oauth/google";
+import { languages } from "@/lib/i18n/settings";
+import { getGlobalData } from "@/api/global";
+import { getEntrySectionTypeByUri, getEntryDataByUri } from "@/api/entry";
+import { setEdcLog } from "@/lib/edc-log";
+import { getSiteFromLocale } from "@/lib/utils";
+import { purgeNextjsStaticFiles } from "@/lib/purgeStaticFiles";
+import { internalLinkWithChildrenShape } from "@/shapes/link";
+import siteInfoShape from "@/shapes/siteInfo";
+import footerContentShape from "@/shapes/footerContent";
+import rootPagesShape from "@/shapes/rootPages";
+import { GlobalDataProvider } from "@/contexts/GlobalData";
+import HomePageTemplate from "@/templates/HomePage";
+
+const GOOGLE_APP_ID = process.env.NEXT_PUBLIC_GOOGLE_APP_ID;
+const CRAFT_HOMEPAGE_URI = "__home__";
+
+export function getStaticPaths() {
+  return {
+    paths: languages.map((language) => {
+      return { params: { locale: language } };
+    }),
+    fallback: "blocking",
+  };
+}
+
+/** @type {import("next").GetStaticProps } */
+export async function getStaticProps({
+  params: { locale },
+  previewData,
+  draftMode,
+}) {
+  const runId = Date.now().toString();
+  const site = getSiteFromLocale(locale);
+  const uri = CRAFT_HOMEPAGE_URI;
+  const previewToken = draftMode ? previewData?.previewToken : undefined;
+
+  const data = await getGlobalData(site);
+
+  const globals = data.globals
+    ? data.globals.reduce(
+        (obj, item) =>
+          Object.assign(
+            obj,
+            Object.keys(item).length && { [item.handle]: item }
+          ),
+        {}
+      )
+    : {};
+
+  const entrySectionType = await getEntrySectionTypeByUri(
+    uri,
+    site,
+    previewToken
+  );
+
+  const { sectionHandle: section, typeHandle: type } = entrySectionType;
+  const entryData = await getEntryDataByUri(
+    uri,
+    section,
+    type,
+    site,
+    previewToken
+  );
+
+  const currentId = entryData?.id || entryData?.entry?.id;
+
+  const globalData = {
+    categories: data?.allCategories || [],
+    footerContent: globals?.footer || {},
+    contactForm: globals?.contactForm || {},
+    headerNavItems: data?.pageTree || [],
+    rootPages: globals?.rootPageInformation?.customBreadcrumbs || [],
+    siteInfo: globals?.siteInfo || {},
+    localeInfo: {
+      locale: site,
+      language: entryData?.language || entryData?.entry?.language || "",
+      localized: entryData?.localized || entryData?.entry?.localized || [],
+    },
+    userProfilePage: data?.userProfilePage || {},
+  };
+
+  // Handle redirect if the entry has one
+  if (entryData?.typeHandle === "redirectPage" && entryData?.linkTo?.url) {
+    setEdcLog(runId, "Redirect build done for " + uri, "BUILD_REDIRECT");
+    return {
+      redirect: {
+        destination: entryData.linkTo.url,
+        permanent: false,
+      },
+    };
+  }
+
+  // Handle 404 if there is no data
+  if (!currentId) {
+    setEdcLog(runId, "404 encountered building for " + uri, "BUILD_ERROR_404");
+    await purgeNextjsStaticFiles(locale);
+    return {
+      notFound: true,
+      revalidate: 10,
+    };
+  }
+  setEdcLog(runId, "Done building for " + uri, "BUILD_COMPLETE");
+
+  return {
+    props: { locale, data: entryData, section, globalData },
+    revalidate: 300,
+  };
+}
+
+const Homepage = ({ section, globalData, ...entryProps }) => {
+  return (
+    <GoogleOAuthProvider clientId={GOOGLE_APP_ID}>
+      <GlobalDataProvider data={globalData}>
+        <HomePageTemplate {...entryProps} />
+      </GlobalDataProvider>
+    </GoogleOAuthProvider>
+  );
+};
+
+Homepage.propTypes = {
+  data: PropTypes.object,
+  section: PropTypes.string,
+  globalData: PropTypes.exact({
+    categories: PropTypes.array,
+    footerContent: footerContentShape,
+    headerNavItems: PropTypes.arrayOf(internalLinkWithChildrenShape),
+    localeInfo: PropTypes.object,
+    rootPages: rootPagesShape,
+    siteInfo: siteInfoShape,
+    userProfilePage: PropTypes.object,
+    contactForm: PropTypes.object,
+  }),
+};
+
+export default Homepage;

--- a/pages/api/preview.js
+++ b/pages/api/preview.js
@@ -27,6 +27,7 @@ const preview = async (request, response) => {
   const site = getSiteFromLocale(
     (searchParams.get("site") || "en").toLowerCase()
   );
+  const isDefaultSite = site === "default";
   const locale = getLocaleString(site);
   const uri = searchParams.get("uri");
 
@@ -47,14 +48,31 @@ const preview = async (request, response) => {
     return response.status(401).send({ message: "Invalid uri" });
   }
 
-  const redirectUri = res.entry.uri === CRAFT_HOMEPAGE_URI ? "" : res.entry.uri;
-  const redirect = `/${locale}/${redirectUri}`;
-  const cookiePath = `${site === "default" ? "" : `/${locale}`}/${redirectUri}`;
-
   // Enable Draft Mode by setting the cookie
   response.setDraftMode({ enable: true });
-  response.setPreviewData({ previewToken }, { path: cookiePath, maxAge: 120 });
-  response.redirect(redirect);
+
+  if (res.entry.uri === CRAFT_HOMEPAGE_URI) {
+    const redirect = `/${locale}`;
+    const cookiePath = isDefaultSite ? "/" : redirect;
+
+    response.redirect(redirect);
+    response.setPreviewData(
+      { previewToken },
+      { path: cookiePath, maxAge: 120 }
+    );
+  } else {
+    const redirectUri = `/${res.entry.uri}`;
+    const redirect = `/${locale}${redirectUri}`;
+    const cookiePath = `${
+      site === "default" ? "" : `/${locale}`
+    }${redirectUri}`;
+
+    response.setPreviewData(
+      { previewToken },
+      { path: cookiePath, maxAge: 120 }
+    );
+    response.redirect(redirect);
+  }
 };
 
 export default preview;


### PR DESCRIPTION
Separate the homepage from the `[...uriSegments]` catch-all since it has unique queries and URI structures. 

Side effect, refactor `getGlobalData` to query by current site rather than querying all sites and then filtering.

## Testing

Optimization benefits of separation:

### Original

- 100kb rendered, 381kb first load JS (per-page)
- 1.4mb total transferred
- 480kb JS

### Separated

- 2.75kb rendered, 352kb first load JS (for homepage)
- 1.3mb total transferred
- 397kb JS

Resolves #495 