### PR TITLE
refactor: replace next/router with next/navigation

### DIFF
--- a/components/atomic/Button/patterns/GoogleSSOButton.js
+++ b/components/atomic/Button/patterns/GoogleSSOButton.js
@@ -1,22 +1,23 @@
 import PropTypes from "prop-types";
 import { useGoogleLogin } from "@react-oauth/google";
-import { useRouter } from "next/router";
+import { usePathname, useRouter } from "next/navigation";
 import { useAuthenticationContext } from "@/contexts/Authentication";
 import SSOButton from "./SSOButton";
+import useQueryParams from "@/lib/routing/useQueryParams";
 
 export default function GoogleSSOButton({ children, ...buttonProps }) {
   const { authenticateWithGoogle } = useAuthenticationContext();
-  const { query, push, asPath, pathname } = useRouter();
+  const { replace } = useRouter();
+  const { queryParams } = useQueryParams();
+  const pathName = usePathname();
+  const params = new URLSearchParams({ sso: true });
+
   const goToGoogleSignIn = useGoogleLogin({
-    state: asPath,
+    state: `${pathName}?${queryParams.toString()}`,
     onSuccess: (response) => {
-      push(
-        { pathname: asPath.split("?")[0], query: { sso: true } },
-        undefined,
-        {
-          shallow: true,
-        }
-      );
+      replace(`${pathName}?${params.toString()}`, {
+        scroll: true,
+      });
       fetch("/api/charming-overlords", {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/components/auth/AuthorizePage/index.js
+++ b/components/auth/AuthorizePage/index.js
@@ -1,6 +1,5 @@
 import PropTypes from "prop-types";
 import { Trans, useTranslation } from "react-i18next";
-import { useRouter } from "next/router";
 import { useAuthModal } from "@/hooks";
 import { useAuthenticationContext } from "@/contexts/Authentication";
 import { Button, Buttonish, Container } from "@rubin-epo/epo-react-lib";
@@ -33,7 +32,6 @@ export default function AuthorizePage({ typeHandle, children }) {
   const { isAuthenticated, user, status, pendingDeletion } =
     useAuthenticationContext();
   const { openModal } = useAuthModal();
-  const router = useRouter();
   const isAuthorizedType = AUTHORIZED_TYPES[typeHandle];
 
   if (!isAuthorizedType) return <>{children}</>;

--- a/components/dynamic/DataList/index.js
+++ b/components/dynamic/DataList/index.js
@@ -1,16 +1,11 @@
-import { useRouter } from "next/router";
 import PropTypes from "prop-types";
 import { useTranslation } from "react-i18next";
 import { Container, Buttonish } from "@rubin-epo/epo-react-lib";
 import Loader from "@/atomic/Loader";
 import Pagination from "@/page/Pagination";
-import {
-  usePathData,
-  normalizePathData,
-  useList,
-  useGlobalData,
-} from "@/lib/utils";
+import { useList, useGlobalData } from "@/lib/utils";
 import * as Styled from "./styles";
+import useQueryParams from "@/lib/routing/useQueryParams";
 
 const DataList = ({
   children,
@@ -27,12 +22,10 @@ const DataList = ({
   loaderDescription,
 }) => {
   const { t } = useTranslation();
-  const { asPath, query } = usePathData();
-  const { pathname, pathParams } = normalizePathData(asPath);
-  const router = useRouter();
+  const { queryParams, setQueryParams } = useQueryParams();
 
   // for the event list, we want to have past events show differently based on querystring type=past
-  if (section === "events" && query?.type === "past") {
+  if (section === "events" && queryParams.get("type") === "past") {
     section = "eventsPast";
   }
 
@@ -62,10 +55,7 @@ const DataList = ({
 
     // if our page is out of bounds, we must instead go to the last page with data
     if (offset > total) {
-      router.push({
-        pathname,
-        query: { ...pathParams, page: numberOfPages },
-      });
+      setQueryParams({ page: numberOfPages });
     }
 
     if (total === 0 && isRelatedList) return null;

--- a/components/global/Header/SearchBar.js
+++ b/components/global/Header/SearchBar.js
@@ -1,10 +1,10 @@
 import { useCallback, useRef, useState } from "react";
-import { useRouter } from "next/router";
 import classNames from "classnames";
 import { useTranslation } from "react-i18next";
 import { useOnClickOutside, useKeyDownEvent } from "@/hooks/listeners";
 import { IconComposer } from "@rubin-epo/epo-react-lib";
-import { getSiteString } from "@/lib/utils";
+import useQueryParams from "@/lib/routing/useQueryParams";
+import { useRouter } from "next/navigation";
 
 const INPUT_ID = "headerSearchBar";
 
@@ -13,11 +13,10 @@ export default function SearchBar() {
   const inputRef = useRef();
   const [open, setOpen] = useState(false);
   const { t } = useTranslation();
-  const router = useRouter();
-  const { query } = router;
-  const site = getSiteString(query.uriSegments);
-  const searchPathname = site === "es" ? "/es/search" : "/search";
-  const [searchText, setSearchText] = useState(query.search || "");
+
+  const { push } = useRouter();
+  const { queryParams } = useQueryParams();
+  const [searchText, setSearchText] = useState(queryParams.get("search") || "");
 
   useKeyDownEvent(handleKeyDown);
   useOnClickOutside(ref, () => {
@@ -42,10 +41,9 @@ export default function SearchBar() {
   const handleSubmit = (event) => {
     event.preventDefault();
 
-    router.push({
-      pathname: searchPathname,
-      query: { search: searchText },
-    });
+    const query = new URLSearchParams({ search: searchText });
+
+    push(`/search?${query.toString()}`);
   };
 
   const handleReset = () => {

--- a/components/layout/NavButtons/index.js
+++ b/components/layout/NavButtons/index.js
@@ -3,7 +3,8 @@ import PropTypes from "prop-types";
 import styled from "styled-components";
 import Link from "next/link";
 import { respond } from "@/styles/globalStyles";
-import { normalizePathData, usePathData } from "@/lib/utils";
+import useQueryParams from "@/lib/routing/useQueryParams";
+import { usePathname } from "next/navigation";
 
 const NavButtons = ({
   hasDefault = true,
@@ -12,13 +13,13 @@ const NavButtons = ({
   textLeft,
   textRight,
 }) => {
-  const { asPath, query } = usePathData();
-  const { pathname, pathParams } = normalizePathData(asPath);
+  const pathname = usePathname();
+  const { queryParams } = useQueryParams();
   const [activeType, setActiveType] = useState();
 
   useEffect(() => {
-    setActiveType(query.type);
-  }, [query]);
+    setActiveType(queryParams.get("type"));
+  }, [queryParams]);
 
   return (
     <Nav>
@@ -27,7 +28,7 @@ const NavButtons = ({
         prefetch={false}
         href={{
           pathname,
-          query: { ...pathParams, page: 1, type: linkLeft },
+          query: { ...queryParams, page: 1, type: linkLeft },
         }}
         passHref={true}
       >
@@ -45,7 +46,7 @@ const NavButtons = ({
         prefetch={false}
         href={{
           pathname,
-          query: { ...pathParams, page: 1, type: linkRight },
+          query: { ...queryParams, page: 1, type: linkRight },
         }}
         passHref={true}
       >

--- a/components/modal/ActivateModal/index.js
+++ b/components/modal/ActivateModal/index.js
@@ -1,17 +1,20 @@
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { useRouter } from "next/router";
 import { useAuthenticationContext } from "@/contexts/Authentication";
 import useAuthModal from "@/hooks/useAuthModal";
 import { Button } from "@rubin-epo/epo-react-lib";
 import AuthModal from "../AuthModal";
 import * as Styled from "./styles";
+import useQueryParams from "@/lib/routing/useQueryParams";
 
 export default function ActivateModal() {
   const { closeModal } = useAuthModal();
+  const { queryParams } = useQueryParams();
 
-  const { query } = useRouter();
-  const { activate, code, id, educator } = query;
+  const activate = queryParams.get("activate");
+  const code = queryParams.get("code");
+  const id = queryParams.get("id");
+  const educator = queryParams.get("educator");
 
   const { t } = useTranslation();
 

--- a/components/modal/ForgotPasswordModal/index.js
+++ b/components/modal/ForgotPasswordModal/index.js
@@ -1,17 +1,18 @@
 import { useState } from "react";
 import { useTranslation, Trans } from "react-i18next";
-import { useRouter } from "next/router";
 import { useForm } from "react-hook-form";
 import { useAuthenticationContext } from "@/contexts/Authentication";
 import useAuthModal from "@/hooks/useAuthModal";
 import { Button, FormField, Input } from "@rubin-epo/epo-react-lib";
 import AuthModal from "../AuthModal";
 import * as Styled from "./styles";
+import useQueryParams from "@/lib/routing/useQueryParams";
 
 export default function ForgotPasswordModal() {
   const { openModal, closeModal } = useAuthModal();
 
-  const { query } = useRouter();
+  const { queryParams } = useQueryParams();
+  const isOpen = !!queryParams.get("forgotPassword");
 
   const { t } = useTranslation();
 
@@ -61,7 +62,7 @@ export default function ForgotPasswordModal() {
 
   return (
     <AuthModal
-      open={!!query.forgotPassword}
+      open={isOpen}
       onClose={onClose}
       aria-label={t("reset_password.header")}
     >

--- a/components/modal/RegisterModal/index.js
+++ b/components/modal/RegisterModal/index.js
@@ -1,15 +1,17 @@
-import { useRouter } from "next/router";
 import { useTranslation, Trans } from "react-i18next";
 import { useAuthenticationContext } from "@/contexts/Authentication";
 import RegisterForm from "./RegisterForm";
 import useAuthModal from "@/hooks/useAuthModal";
+import useQueryParams from "@/lib/routing/useQueryParams";
 import { Button } from "@rubin-epo/epo-react-lib";
 import AuthModal from "../AuthModal";
 import JoinForm from "./JoinForm";
 import * as Styled from "./RegisterForm/styles";
 
 export default function RegisterModal() {
-  const { query } = useRouter();
+  const { queryParams } = useQueryParams();
+  const isOpen = !!queryParams.get("register");
+  const group = queryParams.get("group");
 
   const { openModal, closeModal } = useAuthModal();
 
@@ -32,7 +34,7 @@ export default function RegisterModal() {
 
   return (
     <AuthModal
-      open={!!query.register}
+      open={isOpen}
       onClose={onClose}
       aria-label={t("register.header")}
       image={isAuthenticated ? undefined : pendingGroup}
@@ -53,7 +55,7 @@ export default function RegisterModal() {
             <Button onClick={onClose}>{t("register.confirm_button")}</Button>
           </Styled.FormButtons>
         </>
-      ) : query.group === "educators" || query.group === "students" ? (
+      ) : group === "educators" || group === "students" ? (
         <RegisterForm onCancel={onCancel} />
       ) : (
         <JoinForm onEmailSignup={onEmailSignup} />

--- a/components/modal/SSOModal/index.js
+++ b/components/modal/SSOModal/index.js
@@ -1,13 +1,14 @@
-import { useRouter } from "next/router";
 import { useTranslation, Trans } from "react-i18next";
 import { useAuthenticationContext } from "@/contexts/Authentication";
 import useAuthModal from "@/hooks/useAuthModal";
+import useQueryParams from "@/lib/routing/useQueryParams";
 import { Button } from "@rubin-epo/epo-react-lib";
 import AuthModal from "../AuthModal";
 import * as Styled from "./styles";
 
 export default function SSOModal() {
-  const { query } = useRouter();
+  const { queryParams } = useQueryParams();
+  const isOpen = !!queryParams.get("sso");
 
   const { closeModal } = useAuthModal();
 
@@ -20,11 +21,11 @@ export default function SSOModal() {
     closeModal();
   };
 
-  const service = query.facebook ? "facebook" : "google";
+  const service = queryParams.get("facebook") ? "facebook" : "google";
 
   return (
     <AuthModal
-      open={!!query.sso}
+      open={isOpen}
       onClose={onClose}
       aria-label={t("sign_in.loading", {
         service,

--- a/components/modal/SetPasswordModal/index.js
+++ b/components/modal/SetPasswordModal/index.js
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { useRouter } from "next/router";
 import { useForm } from "react-hook-form";
+import useQueryParams from "@/lib/routing/useQueryParams";
 import { useAuthenticationContext } from "@/contexts/Authentication";
 import useAuthModal from "@/hooks/useAuthModal";
 import { Button, Error } from "@rubin-epo/epo-react-lib";
@@ -11,9 +11,10 @@ import * as Styled from "./styles";
 
 export default function SetPasswordModal() {
   const { closeModal } = useAuthModal();
-
-  const { query } = useRouter();
-  const { set_password, code, id } = query; // eslint-disable-line camelcase
+  const { queryParams } = useQueryParams();
+  const isOpen = !!queryParams.get("set_password");
+  const code = queryParams.get("code");
+  const id = queryParams.get("id");
 
   const { t } = useTranslation();
 
@@ -64,7 +65,7 @@ export default function SetPasswordModal() {
 
   return (
     <AuthModal
-      open={!!set_password} // eslint-disable-line camelcase
+      open={isOpen} // eslint-disable-line camelcase
       onClose={onClose}
       aria-label={t("set_password.header")}
     >

--- a/components/modal/SignInModal/index.js
+++ b/components/modal/SignInModal/index.js
@@ -1,8 +1,8 @@
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { useRouter } from "next/router";
 import Link from "next/link";
 import { useForm } from "react-hook-form";
+import useQueryParams from "@/lib/routing/useQueryParams";
 import { useAuthenticationContext } from "@/contexts/Authentication";
 import useAuthModal from "@/hooks/useAuthModal";
 import { GoogleSSOButton } from "@/components/atomic";
@@ -18,7 +18,8 @@ import AuthModal from "../AuthModal";
 import * as Styled from "./styles";
 
 export default function SignInModal() {
-  const { query } = useRouter();
+  const { queryParams } = useQueryParams();
+  const isOpen = !!queryParams.get("signIn");
 
   const { t } = useTranslation();
 
@@ -78,11 +79,7 @@ export default function SignInModal() {
   };
 
   return (
-    <AuthModal
-      open={!!query.signIn}
-      onClose={onClose}
-      aria-label={t("sign_in.header")}
-    >
+    <AuthModal open={isOpen} onClose={onClose} aria-label={t("sign_in.header")}>
       {isAuthenticated && status === "active" ? ( // included only in case a user inadvertantly reopens the modal
         <>
           <AuthModal.Title>{t("sign_in.success")}</AuthModal.Title>

--- a/components/page/FilterBar/index.js
+++ b/components/page/FilterBar/index.js
@@ -4,16 +4,22 @@ import { useTranslation } from "react-i18next";
 import { MixedLink, IconComposer } from "@rubin-epo/epo-react-lib";
 import T from "@/page/Translate";
 import { useOnClickOutside } from "@/hooks/listeners";
-import { usePathData, getCategoryGroup, useGlobalData } from "@/lib/utils";
+import { getCategoryGroup, useGlobalData } from "@/lib/utils";
 import withLiveRegionChange from "@/hoc/withLiveRegionChange";
 import { useFilterParams } from "@/contexts/FilterParams";
 import * as Styled from "./styles";
+import { usePathname } from "next/navigation";
+import useQueryParams from "@/lib/routing/useQueryParams";
 
 const FilterBar = ({ filterType, setLiveRegionMessage }) => {
   const { params, hidden = [], setParams, resetParams } = useFilterParams();
   const { t } = useTranslation();
   const ref = useRef();
-  const { asPath } = usePathData();
+  const pathname = usePathname();
+  const { queryParams } = useQueryParams();
+  const paramsWithoutLocale = new URLSearchParams(queryParams);
+  paramsWithoutLocale.delete("locale");
+  const asPath = `${pathname}?${paramsWithoutLocale.toString()}`;
   const { categories } = useGlobalData();
   const filterMap = {
     events: "eventFilters",

--- a/components/page/Pagination/index.js
+++ b/components/page/Pagination/index.js
@@ -1,15 +1,20 @@
 import React from "react";
+import { usePathname } from "next/navigation";
 import styled from "styled-components";
 import { useTranslation } from "react-i18next";
 import PropTypes from "prop-types";
 import { Container, MixedLink } from "@rubin-epo/epo-react-lib";
+import useQueryParams from "@/lib/routing/useQueryParams";
 import T from "@/page/Translate";
-import { usePathData } from "@/lib/utils";
 import { layoutGrid, respond } from "@/styles/globalStyles";
 
 const Pagination = ({ limit, offset, page, total }) => {
   const { t } = useTranslation();
-  const { asPath } = usePathData();
+  const pathname = usePathname();
+  const { queryParams } = useQueryParams();
+  const paramsWithoutLocale = new URLSearchParams(queryParams);
+  paramsWithoutLocale.delete("locale");
+  const asPath = `${pathname}?${paramsWithoutLocale.toString()}`;
   const currentPage = parseInt(page);
   const from = offset + 1;
   let to = offset + limit;
@@ -135,7 +140,7 @@ const NavDesktop = styled.nav`
 
 const NavMobile = styled.nav`
   display: none;
-  ${respond(`    
+  ${respond(`
     display: grid;
     width: 100%;
     grid-template-columns: 1fr 1fr;

--- a/components/templates/Page/index.js
+++ b/components/templates/Page/index.js
@@ -9,7 +9,7 @@ import { Container } from "@rubin-epo/epo-react-lib";
 import Breadcrumbs from "@/page/Breadcrumbs";
 import FilterBar from "@/components/page/FilterBar";
 import SlideBlock from "@/components/content-blocks/SlideBlock";
-import { getCategoryObject, useGlobalData, usePathData } from "@/lib/utils";
+import { getCategoryObject, useGlobalData } from "@/lib/utils";
 import NavButtons from "@/components/layout/NavButtons";
 import SubHero from "@/components/page/SubHero";
 import AuthorizePage from "@/components/auth/AuthorizePage";
@@ -21,6 +21,7 @@ import NestedContext from "@/contexts/Nested";
 import PageContent from "@/page/PageContent";
 import MediaAside from "@/components/page/Aside/patterns/Media";
 import { FilterParamsProvider } from "@/contexts/FilterParams";
+import useQueryParams from "@/lib/routing/useQueryParams";
 
 export default function Page({
   data: {
@@ -93,8 +94,8 @@ export default function Page({
 
   // custom page name for gallery search
   const isGallerySearch = uri === "gallery/gallery-search";
-  const { query } = usePathData();
-  const categoryId = query.filter;
+  const { queryParams } = useQueryParams();
+  const categoryId = queryParams.get("filter");
   const categories = useGlobalData("categories");
   let categoryObj;
   if (isGallerySearch && categories && categoryId) {

--- a/components/templates/SearchPage/index.js
+++ b/components/templates/SearchPage/index.js
@@ -5,9 +5,9 @@ import Breadcrumbs from "@/components/page/Breadcrumbs";
 import { Container } from "@rubin-epo/epo-react-lib";
 import DynamicComponentFactory from "@/components/factories/DynamicComponentFactory";
 import FilterBar from "@/components/page/FilterBar";
-import { usePathData } from "@/lib/utils";
 import { BREAK_PHABLET } from "@/styles/globalStyles";
 import { FilterParamsProvider } from "@/contexts/FilterParams";
+import useQueryParams from "@/lib/routing/useQueryParams";
 
 export default function SearchPage({
   data: { description, dynamicComponent, id, title, uri },
@@ -21,10 +21,11 @@ export default function SearchPage({
     uri,
     title,
   };
-  const { query } = usePathData();
+  const { queryParams } = useQueryParams();
+  const search = queryParams.get("search");
   const keyphrase =
-    query.search &&
-    query.search.replace("+", " ").replace(/(^|\s)\S/g, (t) => t.toUpperCase());
+    search &&
+    search.replace("+", " ").replace(/(^|\s)\S/g, (t) => t.toUpperCase());
 
   return (
     <Body {...bodyProps}>

--- a/hooks/useAuthModal.js
+++ b/hooks/useAuthModal.js
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import { useRouter } from "next/router";
+import { usePathname, useRouter } from "next/navigation";
 
 // const MODALS = ["signIn", "register", "forgotPassword"];
 
@@ -7,11 +7,10 @@ import { useRouter } from "next/router";
 
 export default function useAuthModal() {
   const router = useRouter();
+  const pathName = usePathname();
 
   const getModalUrlObj = useCallback(
     (nameParam, queryVars) => {
-      const path = router.asPath.split("?");
-
       const query = {
         ...(nameParam && {
           [nameParam]: true,
@@ -21,18 +20,16 @@ export default function useAuthModal() {
         }),
       };
 
-      return { pathname: path[0], query };
+      return { pathname: pathName, query };
     },
-    [router]
+    [pathName]
   );
 
   const doRouterPush = useCallback(
     (nameParam, queryVars) => {
       const url = getModalUrlObj(nameParam, queryVars);
 
-      router.push(url, undefined, {
-        shallow: true,
-      });
+      router.push(url);
     },
     [router, getModalUrlObj]
   );

--- a/hooks/useAuthentication.js
+++ b/hooks/useAuthentication.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useRouter } from "next/router";
+import { useRouter, usePathname } from "next/navigation";
 import jwtDecode from "jwt-decode";
 import {
   authenticate,
@@ -15,6 +15,7 @@ import {
   fetchUser,
   requestDeletion,
 } from "@/lib/api/auth";
+import useQueryParams from "@/lib/routing/useQueryParams";
 
 const SESSION_STORAGE_KEYS = [
   "jwt",
@@ -62,7 +63,9 @@ function normalizeLanguage(language) {
 
 // TODO: store refresh token in cookie so token can be refreshed after browser session ends
 export default function useAuthentication(data) {
-  const { query, push, asPath } = useRouter();
+  const { push } = useRouter();
+  const { queryParams } = useQueryParams();
+  const pathName = usePathname();
 
   const [token, setToken] = useState(getTokenFromStorage("jwt"));
   const [user, setUser] = useState(getUserFromJwt());
@@ -96,9 +99,10 @@ export default function useAuthentication(data) {
   }, [pendingGroup]);
 
   useEffect(() => {
-    if (!query.code || !query.facebook) return;
-    (async () => await authenticateWithFacebook({ code: query.code }))();
-  }, [query]); // eslint-disable-line react-hooks/exhaustive-deps
+    if (!queryParams.get("code") || !queryParams.get("facebook")) return;
+    (async () =>
+      await authenticateWithFacebook({ code: queryParams.get("code") }))();
+  }, [queryParams]); // eslint-disable-line react-hooks/exhaustive-deps
 
   function clearState() {
     setToken(null);
@@ -337,7 +341,7 @@ export default function useAuthentication(data) {
     const data = await getFacebookOauthUrl();
     if (data?.facebookOauthUrl) {
       const facebookOauthUrl = data.facebookOauthUrl;
-      const state = asPath.split("?")[0];
+      const state = pathName;
       const startSplitter = "&state=";
       const endSplitter = "&response_type";
       const startOfFacebookOauthUrl = facebookOauthUrl.split(startSplitter)[0];

--- a/lib/routing/useQueryParams.js
+++ b/lib/routing/useQueryParams.js
@@ -1,0 +1,42 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+export default function useQueryParams() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const urlSearchParams = new URLSearchParams(searchParams?.toString());
+
+  /**
+   * @param {Record<string, any>} params
+   */
+  function setQueryParams(params, push = false) {
+    Object.entries(params).forEach(([key, value]) => {
+      if (value === undefined || value === null) {
+        urlSearchParams.delete(key);
+      } else {
+        urlSearchParams.set(key, String(value));
+      }
+    });
+
+    const search = urlSearchParams.toString();
+    const query = search ? `?${search}` : "";
+
+    if (push) {
+      router.push(`${pathname}${query}`);
+    } else {
+      router.replace(`${pathname}${query}`);
+    }
+  }
+
+  function clearQueryParams(push = false) {
+    if (push) {
+      router.push(pathname);
+    } else {
+      router.replace(pathname);
+    }
+  }
+
+  return { queryParams: searchParams, setQueryParams, clearQueryParams };
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,11 +1,11 @@
 import { useContext, useEffect } from "react";
-import { useRouter } from "next/router";
 import GlobalDataContext from "@/contexts/GlobalData";
 import { useDataList } from "@/api/entries";
 import { useReleases } from "@/lib/api/noirlabReleases";
 import debounce from "lodash/debounce";
 import { useFilterParams } from "@/contexts/FilterParams";
 import { fallbackLng } from "./i18n/settings";
+import { usePathname } from "next/navigation";
 
 export const getLinearScale = (domain, range, clamp = false) => {
   return (val) => {
@@ -83,9 +83,9 @@ export const useList = ({
   listTypeId = null,
   section,
 }) => {
-  const { asPath } = useRouter();
+  const pathName = usePathname();
   const { params } = useFilterParams();
-  const site = getSiteString(asPath);
+  const site = getSiteString(pathName);
   const adjustedLimit = adjustLimit(limit, params.page, showsFeatured);
   const offset = getOffset(limit, params.page, showsFeatured);
   const inReverse = params.sort === "descending";
@@ -98,7 +98,6 @@ export const useList = ({
   } else if (!isSitewideSearch) {
     listTypeId = getListTypeId(params.filter, listTypeId);
   }
-
   const results = useDataList({
     excludeId,
     inReverse,
@@ -139,9 +138,8 @@ export const useListForBlock = ({
   listTypeId = null,
   section,
 }) => {
-  const router = useRouter();
-  const { asPath, query } = router;
-  const site = getSiteString(asPath);
+  const pathName = usePathname();
+  const site = getSiteString(pathName);
 
   const results = useDataList({
     excludeId,
@@ -174,14 +172,6 @@ export const useCustomBreadcrumbs = (rootPageString) => {
     .filter((p) => p.header?.includes(rootPageString))
     .map((p) => p.pageEntry);
   return customBreadcrumbs.flat(1);
-};
-
-export const usePathData = () => {
-  // this returns the post-domain url goodies from the router
-
-  const router = useRouter();
-  const { asPath, pathname, query } = router;
-  return { asPath, pathname, query };
 };
 
 function dateWoTimezone(iso) {
@@ -303,28 +293,6 @@ export const makeDateObject = (date, locale = fallbackLng, isShort = false) => {
     day: newDate.getDate(),
   };
   return dateObject;
-};
-
-export const normalizePathData = (pathnameInput) => {
-  // params should come in as an object, { key: "value" }
-  // however, if there is a querystring in the pathname, we must split them
-  // so they are ready to be like this in the calling component:
-  // const href = {
-  //   pathname: simplePathname,
-  //   query: { ...pathParams, ...params },
-  // };
-  if (!pathnameInput) return { pathParams: {} };
-
-  const pathnameArray = pathnameInput.split("?");
-  const simplePathname = pathnameArray.shift();
-  const pathname =
-    simplePathname.startsWith("/") || simplePathname.startsWith("mailto")
-      ? simplePathname
-      : "/" + simplePathname;
-  const urlParams = new URLSearchParams(pathnameArray.shift());
-  const pathParams = Object.fromEntries(urlParams);
-
-  return { pathname, pathParams };
 };
 
 export const checkIfBetweenDates = (startDate, endDate) => {


### PR DESCRIPTION
Replaces instances of `next/router` with the app directory compatible `next/navigation`. Replacements include:

- `router.query` replaced with `useQueryParams` hook that composes `useSearchParams` and `usePathname`
- `router.pathname` replaced with `usePathname`
- `router.asPath` replaced with combining `usePathname` and `useQueryParams`
- `usePathData` and `normalizePathData` deprecated and removed in favor of `usePathname` and `useQueryParams`

Resolves #513 

## Changes to test

- open modals with query params:
  - ?signIn=true - sign in
  - ?activate=true - activate account (requires code and id param also, will show error otherwise)
  - ?forgotPassword=true - forgot password
  - ?register=true - registration start
  - ?set_password=true - set password
  - ?sso=true - Google signin (will just be a blank modal)
- can change search input
- can change filter input
- can navigate through pagination