### PR TITLE
refactor: add revalidatePath support to revalidate endpoint

### DIFF
--- a/app/api/app-revalidate/route.ts
+++ b/app/api/app-revalidate/route.ts
@@ -1,0 +1,37 @@
+import { revalidatePath } from "next/cache";
+import { NextRequest, NextResponse } from "next/server";
+
+const REVALIDATE_SECRET_TOKEN = process.env.CRAFT_REVALIDATE_SECRET_TOKEN;
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const uri = request.nextUrl.searchParams.get("uri");
+  const secret = request.nextUrl.searchParams.get("secret");
+
+  if (!uri) {
+    return NextResponse.json({
+      revalidated: false,
+      now: Date.now(),
+      message: "Missing path to revalidate",
+    });
+  }
+
+  if (secret !== REVALIDATE_SECRET_TOKEN) {
+    return NextResponse.json({
+      revalidated: false,
+      now: Date.now(),
+      message: "Invalid token",
+    });
+  }
+
+  if (uri) {
+    revalidatePath(`/[locale]/${uri}`, "page");
+
+    return NextResponse.json({ revalidated: true, now: Date.now() });
+  }
+
+  return NextResponse.json({
+    revalidated: false,
+    now: Date.now(),
+    message: "Error revalidating",
+  });
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/pages/api/revalidate.js
+++ b/pages/api/revalidate.js
@@ -1,6 +1,14 @@
 /* eslint-disable no-console */
 import { isCraftPreview } from "@/helpers";
 
+const REVALIDATE_SECRET_TOKEN = process.env.CRAFT_REVALIDATE_SECRET_TOKEN;
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
+
+/**
+ * @function preview
+ * @param {import("next").NextApiRequest} req
+ * @param {import("next").NextApiResponse} res
+ */
 async function handler(req, res) {
   const { query } = req;
   const isPreview = isCraftPreview(query);
@@ -12,7 +20,7 @@ async function handler(req, res) {
     });
   }
 
-  if (query.secret !== process.env.CRAFT_REVALIDATE_SECRET_TOKEN) {
+  if (query.secret !== REVALIDATE_SECRET_TOKEN) {
     console.warn("Invalid token");
     return res.status(401).json({ error: "Invalid token" });
   }
@@ -23,6 +31,9 @@ async function handler(req, res) {
   }
 
   try {
+    const searchParams = new URLSearchParams(query);
+
+    await fetch(`${BASE_URL}/api/app-revalidate?${searchParams.toString()}`);
     await res.revalidate(`/${query.uri}`);
     return res.status(200).json({ revalidated: true });
   } catch (error) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "compilerOptions": {
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -20,29 +24,78 @@
     "baseUrl": ".",
     "strictNullChecks": true,
     "paths": {
-      "@/lib/*": ["lib/*"],
-      "@/api/*": ["lib/api/*"],
-      "@/charts/*": ["charts/*"],
-      "@/components/*": ["components/*"],
-      "@/content-blocks": ["components/content-blocks"],
-      "@/dynamic/*": ["components/dynamic/*"],
-      "@/factories/*": ["components/factories/*"],
-      "@/atomic/*": ["components/atomic/*"],
-      "@/layout/*": ["components/layout/*"],
-      "@/templates/*": ["components/templates/*"],
-      "@/global/*": ["components/global/*"],
-      "@/page/*": ["components/page/*"],
-      "@/shapes/*": ["components/shapes/*"],
-      "@/hooks/*": ["hooks/*"],
-      "@/hooks": ["hooks"],
-      "@/contexts/*": ["contexts/*"],
-      "@/styles/*": ["theme/styles/*"],
-      "@/svg/*": ["components/svg/*"],
-      "@/helpers": ["helpers"],
-      "@/helpers/*": ["helpers/*"],
-      "@/hoc/*": ["components/hoc/*"]
+      "@/lib/*": [
+        "lib/*"
+      ],
+      "@/api/*": [
+        "lib/api/*"
+      ],
+      "@/charts/*": [
+        "charts/*"
+      ],
+      "@/components/*": [
+        "components/*"
+      ],
+      "@/content-blocks": [
+        "components/content-blocks"
+      ],
+      "@/dynamic/*": [
+        "components/dynamic/*"
+      ],
+      "@/factories/*": [
+        "components/factories/*"
+      ],
+      "@/atomic/*": [
+        "components/atomic/*"
+      ],
+      "@/layout/*": [
+        "components/layout/*"
+      ],
+      "@/templates/*": [
+        "components/templates/*"
+      ],
+      "@/global/*": [
+        "components/global/*"
+      ],
+      "@/page/*": [
+        "components/page/*"
+      ],
+      "@/shapes/*": [
+        "components/shapes/*"
+      ],
+      "@/hooks/*": [
+        "hooks/*"
+      ],
+      "@/hooks": [
+        "hooks"
+      ],
+      "@/contexts/*": [
+        "contexts/*"
+      ],
+      "@/styles/*": [
+        "theme/styles/*"
+      ],
+      "@/svg/*": [
+        "components/svg/*"
+      ],
+      "@/helpers": [
+        "helpers"
+      ],
+      "@/helpers/*": [
+        "helpers/*"
+      ],
+      "@/hoc/*": [
+        "components/hoc/*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
Adds an app directory Route Handler that performs revalidation to support to our existing `revalidate` endpoint. The existing `api/revalidate` endpoint will call this new `api/app-revalidate` endpoint with the same arguments.

Testing this is tricky, since we do not have any app directory routes, but can be done with the following:

- add an `app` folder with `[locale]` as a child folder, and `my-page` as a folder within `[locale]`. 
```
app
|- [locale]
  |- my-page
    |- page.jsx
```

- add a `page.jsx` to `my-page` that default exports a React component. Inside the component, fetch a random number from an API and display it.
- 
```jsx
const Page = async () => {
    const response = await fetch('http://www.randomnumberapi.com/api/v1.0/random?min=100&max=1000&count=1');
    const number = await response.json();

    return <h1>{number}</h1>
}
```

- In `app/api/app-revalidate/route.ts` add `revalidatePath('/[locale]/my-page', 'page')` after the existing `revalidatePath`
- Start a production build with `yarn bs`
- Visit `/es/my-page` and refresh a few times, the number should not change.
- Save an entry in CraftCMS, look for any console errors
- Visit `/es/my-page` again and the number should change

Resolves #514 