### PR TITLE
fix: re-order preview data set

### DIFF
--- a/pages/api/preview.js
+++ b/pages/api/preview.js
@@ -55,11 +55,11 @@ const preview = async (request, response) => {
     const redirect = `/${locale}`;
     const cookiePath = isDefaultSite ? "/" : redirect;
 
-    response.redirect(redirect);
     response.setPreviewData(
       { previewToken },
       { path: cookiePath, maxAge: 120 }
     );
+    response.redirect(redirect);
   } else {
     const redirectUri = `/${res.entry.uri}`;
     const redirect = `/${locale}${redirectUri}`;


### PR DESCRIPTION
`setPreviewData` needs to be in front of `redirect` or it will never be reached