### PR TITLE
fix: do not encode URI slashes

### DIFF
--- a/lib/api/sitemap/index.ts
+++ b/lib/api/sitemap/index.ts
@@ -16,7 +16,8 @@ export const generateSitemapUrl = (
   locale: string,
   preserveLocale = false
 ) => {
-  const segments = uri === CRAFT_HOMEPAGE_URI ? [] : [encodeURIComponent(uri)];
+  const segments =
+    uri === CRAFT_HOMEPAGE_URI ? [] : uri.split("/").map(encodeURIComponent);
 
   if (preserveLocale || locale !== fallbackLng) {
     segments.unshift(locale);


### PR DESCRIPTION
Bing couldn't parse URL's where the slashes were encoded, so instead just encode the segments and then re-combine.