### PR TITLE
feat: set up IndexNow

### DIFF
--- a/app/api/indexnow/[keyFile]/route.ts
+++ b/app/api/indexnow/[keyFile]/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest } from "next/server";
+
+type IndexNowParams = {
+  keyFile: string;
+};
+
+interface IndexNowProps {
+  params: IndexNowParams;
+}
+
+const BING_INDEXNOW_KEY = process.env.BING_INDEXNOW_KEY;
+
+export async function GET(
+  request: NextRequest,
+  { params: { keyFile } }: IndexNowProps
+): Promise<Response> {
+  const [fileName, fileType] = keyFile.split(".");
+
+  if (!BING_INDEXNOW_KEY) {
+    return new Response("No key found", { status: 500 });
+  }
+
+  if (fileType !== "txt") {
+    return new Response("Invalid file type", { status: 400 });
+  }
+
+  if (fileName !== BING_INDEXNOW_KEY) {
+    return new Response("Invalid key", { status: 400 });
+  }
+
+  return new Response(BING_INDEXNOW_KEY, {
+    headers: {
+      "Content-Type": "text/plain",
+    },
+  });
+}

--- a/cypress/e2e/api/indexnow.cy.js
+++ b/cypress/e2e/api/indexnow.cy.js
@@ -1,0 +1,38 @@
+const indexNowKey = Cypress.env("BING_INDEXNOW_KEY");
+const baseUrl = "/api/indexnow/";
+const keyFile = `${indexNowKey}.txt`;
+const invalidFileName = `123.txt`;
+const invalidFileType = `${indexNowKey}.pdf`;
+
+context("GET /api/indexnow/[keyFile]", () => {
+  it("rejects requests with incorrect file type", () => {
+    cy.request({
+      url: `${baseUrl}${invalidFileType}`,
+      method: "GET",
+      failOnStatusCode: false,
+    }).then(({ status, body }) => {
+      expect(body).to.eq("Invalid file type");
+      expect(status).to.eq(400);
+    });
+  });
+  it("rejects requests with incorrect filename", () => {
+    cy.request({
+      url: `${baseUrl}${invalidFileName}`,
+      method: "GET",
+      failOnStatusCode: false,
+    }).then(({ status, body }) => {
+      expect(body).to.eq("Invalid key");
+      expect(status).to.eq(400);
+    });
+  });
+  it("returns an indexNow key", () => {
+    cy.request({
+      url: `${baseUrl}${keyFile}`,
+      method: "GET",
+    }).then(({ status, body, headers }) => {
+      expect(body).to.eq(indexNowKey);
+      expect(headers["content-type"]).to.eq("text/plain");
+      expect(status).to.eq(200);
+    });
+  });
+});


### PR DESCRIPTION
Resolves #579 

Modifications to two Next route handlers to support [IndexNow](https://www.indexnow.org/documentation) for Bing search.

First is a new keyfile route handler that provides our IndexNow API key, read from the server environment, as a text file that Bing will read when receiving requests to re-index pages.

Second is an addition to our revalidation endpoint that creates a URL list of updates to send to Bing, and console logs the result. 

I'm not sure of how to test this outside of a production environment since Bing does not provide any dev environments to test against. Testing on a lower environment would mean entering those sites into the search index, which we do not want. 

The best I have is providing an E2E test for the keyfile, and console logging on production.