### PR TITLE
fix: add canonical to document meta

### DIFF
--- a/app/[locale]/[...uriSegments]/page.tsx
+++ b/app/[locale]/[...uriSegments]/page.tsx
@@ -83,6 +83,7 @@ export async function generateMetadata(
     openGraph: {
       images: featuredImage || previousImages,
     },
+    alternates: { canonical: "./" },
   };
 }
 

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -21,7 +21,7 @@ export async function generateMetadata({
     entry: { title, description },
   } = await getHomepageMetadata(locale, previewToken);
 
-  return { title, description };
+  return { title, description, alternates: { canonical: "./" } };
 }
 
 const RootPage: FunctionComponent<LocaleProps> = async ({


### PR DESCRIPTION
Resolves #590 

Adds a `canonical` tag to each page so that search engines do not attempt to index query params