### PR TITLE
feat: twitter + google meta tags

### DIFF
--- a/app/[locale]/[...uriSegments]/page.tsx
+++ b/app/[locale]/[...uriSegments]/page.tsx
@@ -83,7 +83,6 @@ export async function generateMetadata(
     openGraph: {
       images: featuredImage || previousImages,
     },
-    alternates: { canonical: "./" },
   };
 }
 

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -22,7 +22,7 @@ export async function generateMetadata({
   }
 
   const { siteInfo: metadata } = await getGlobalData(locale);
-  const { siteTitle, siteDescription, siteImage, language } = metadata;
+  const { siteTitle, siteDescription, siteImage, language, twitter } = metadata;
   const { url, width, height, altText: alt } = siteImage[0];
 
   return {
@@ -32,9 +32,14 @@ export async function generateMetadata({
     },
     description: siteDescription,
     manifest: "/site.webmanifest",
+    alternates: { canonical: "./" },
     openGraph: {
       locale: language,
       images: [{ url, width, height, alt }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      site: `@${twitter.substring(twitter.lastIndexOf("/") + 1)}`,
     },
     icons: {
       icon: [
@@ -44,6 +49,11 @@ export async function generateMetadata({
       apple: [
         { url: "/apple-touch-icon.png", sizes: "180x180", type: "image/png" },
       ],
+    },
+    robots: {
+      googleBot: {
+        "max-image-preview": "large",
+      },
     },
   };
 }

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -21,7 +21,7 @@ export async function generateMetadata({
     entry: { title, description },
   } = await getHomepageMetadata(locale, previewToken);
 
-  return { title, description, alternates: { canonical: "./" } };
+  return { title, description };
 }
 
 const RootPage: FunctionComponent<LocaleProps> = async ({

--- a/lib/api/noirlab/index.ts
+++ b/lib/api/noirlab/index.ts
@@ -55,7 +55,10 @@ export const generateReleaseMetadata = async (id: string, locale: string) => {
 
   return {
     title: data?.title,
-    description: data?.headline,
+    description: data?.subtitle,
+    twitter: {
+      title: data?.title,
+    },
     openGraph: {
       images: getReleaseOpenGraph(data?.images),
     },


### PR DESCRIPTION
Resolves #596, #564 

- moves canonical up to root level
- adds Twitter handle
- adds large preview image for Google