### PR TITLE
refactor: preview token into session

### DIFF
--- a/app/[locale]/[...uriSegments]/layout.tsx
+++ b/app/[locale]/[...uriSegments]/layout.tsx
@@ -1,6 +1,5 @@
 import { FC, PropsWithChildren } from "react";
 import { Metadata, ResolvingMetadata } from "next";
-import { draftMode } from "next/headers";
 import { notFound } from "next/navigation";
 import { OpenGraph } from "next/dist/lib/metadata/types/opengraph-types";
 import striptags from "striptags";
@@ -53,19 +52,8 @@ export async function generateMetadata(
   parent: ResolvingMetadata
 ): Promise<Metadata> {
   const uri = uriSegments.join("/");
-  let previewToken: string | undefined;
 
-  if (draftMode().isEnabled) {
-    previewToken = Array.isArray(searchParams.preview)
-      ? searchParams.preview[0]
-      : searchParams?.preview;
-  }
-
-  const entrySectionType = await getEntrySectionByUri(
-    uri,
-    locale,
-    previewToken
-  );
+  const entrySectionType = await getEntrySectionByUri(uri, locale);
 
   // Handle 404 if there is no data
   if (!entrySectionType) {
@@ -81,7 +69,7 @@ export async function generateMetadata(
     );
   }
 
-  const { entry } = await getEntryMetadataByUri(uri, locale, previewToken);
+  const { entry } = await getEntryMetadataByUri(uri, locale);
 
   if (!entry) {
     notFound();

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -12,6 +12,7 @@ import { AuthenticationContextProvider } from "@/contexts/Authentication";
 import PageWrapper from "@/components/organisms/PageWrapper";
 import RootScripts from "./scripts";
 import { HistoryProvider } from "@/contexts/History";
+import PreviewMode from "@/components/organisms/PreviewMode";
 
 const GOOGLE_APP_ID = process.env.NEXT_PUBLIC_GOOGLE_APP_ID || "";
 
@@ -86,7 +87,9 @@ const LocaleLayout: FunctionComponent<PropsWithChildren<LocaleProps>> = async ({
                 <StyledComponentsRegistry>
                   <GoogleOAuthProvider clientId={GOOGLE_APP_ID}>
                     <GlobalStyles />
-                    <PageWrapper {...{ locale }}>{children}</PageWrapper>
+                    <PreviewMode>
+                      <PageWrapper {...{ locale }}>{children}</PageWrapper>
+                    </PreviewMode>
                   </GoogleOAuthProvider>
                 </StyledComponentsRegistry>
               </AuthenticationContextProvider>

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,42 +1,23 @@
 import { FunctionComponent } from "react";
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { draftMode } from "next/headers";
 import { getHomepage, getHomepageMetadata } from "@/lib/api/homepage";
 import HomePageTemplate from "@/templates/HomePage";
 
 export async function generateMetadata({
   params: { locale },
-  searchParams = {},
-}: WithSearchParams<LocaleProps>): Promise<Metadata> {
-  let previewToken: string | undefined;
-
-  if (draftMode().isEnabled) {
-    previewToken = Array.isArray(searchParams.preview)
-      ? searchParams.preview[0]
-      : searchParams?.preview;
-  }
-
+}: LocaleProps): Promise<Metadata> {
   const {
     entry: { title, description },
-  } = await getHomepageMetadata(locale, previewToken);
+  } = await getHomepageMetadata(locale);
 
   return { title, description };
 }
 
-const RootPage: FunctionComponent<WithSearchParams<LocaleProps>> = async ({
+const RootPage: FunctionComponent<LocaleProps> = async ({
   params: { locale },
-  searchParams = {},
 }) => {
-  let previewToken: string | undefined;
-
-  if (draftMode().isEnabled) {
-    previewToken = Array.isArray(searchParams.preview)
-      ? searchParams.preview[0]
-      : searchParams.preview;
-  }
-
-  const data = await getHomepage(locale, previewToken);
+  const data = await getHomepage(locale);
 
   // Handle 404 if there is no data
   if (!data?.id) {

--- a/app/[locale]/search/page.tsx
+++ b/app/[locale]/search/page.tsx
@@ -1,5 +1,4 @@
 import { FC } from "react";
-import { draftMode } from "next/headers";
 import { notFound } from "next/navigation";
 import Container from "@rubin-epo/epo-react-lib/Container";
 import { getSearchPage } from "@/lib/api/search";
@@ -24,15 +23,8 @@ const SearchPage: FC<WithSearchParams<LocaleProps>> = async ({
   searchParams = {},
 }) => {
   const { search } = searchParams;
-  let previewToken: string | undefined;
 
-  if (draftMode().isEnabled) {
-    previewToken = Array.isArray(searchParams.preview)
-      ? searchParams.preview[0]
-      : searchParams?.preview;
-  }
-
-  const data = await getSearchPage(locale, previewToken);
+  const data = await getSearchPage(locale);
 
   if (!data || !data.id) {
     notFound();

--- a/codegen.ts
+++ b/codegen.ts
@@ -7,6 +7,7 @@ const config: CodegenConfig = {
   generates: {
     "./gql/": {
       documents: [
+        "app/api/**/*.ts",
         "app/[locale]/gallery/**/*.{ts,tsx}",
         "app/[locale]/search/**/*.{ts,tsx}",
         "lib/api/galleries/*.ts",

--- a/components/organisms/PreviewMode/Banner/index.tsx
+++ b/components/organisms/PreviewMode/Banner/index.tsx
@@ -1,0 +1,43 @@
+"use client";
+import { FC, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useTranslation } from "react-i18next";
+import IconComposer from "@rubin-epo/epo-react-lib/IconComposer";
+import endPreviewMode from "@/services/actions/endPreviewMode";
+import styles from "./styles.module.css";
+
+const Banner: FC = () => {
+  const { t } = useTranslation();
+  const [isLivePreview, setLivePreview] = useState(false);
+  const { refresh } = useRouter();
+
+  useEffect(() => {
+    if (window && window.top !== window.self) {
+      setLivePreview(true);
+    }
+  }, []);
+
+  const handleDisable = async () => {
+    await endPreviewMode();
+
+    refresh();
+  };
+
+  if (isLivePreview) return null;
+
+  return (
+    <div className={styles.previewModeBanner}>
+      <span className={styles.info}>
+        <IconComposer icon="InfoCircle" />
+        {t("preview_mode.is_enabled")}
+      </span>
+      <button className={styles.disableButton} onClick={handleDisable}>
+        {t("preview_mode.disable")}
+      </button>
+    </div>
+  );
+};
+
+Banner.displayName = "Organism.PreviewMode.Banner";
+
+export default Banner;

--- a/components/organisms/PreviewMode/Banner/styles.module.css
+++ b/components/organisms/PreviewMode/Banner/styles.module.css
@@ -1,0 +1,28 @@
+.previewModeBanner {
+  background-color: var(--color-rubin-orange-200);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: var(--size-spacing-m);
+  width: 100%;
+  font-size: 0.85rem;
+  padding: 0 var(--size-spacing-2xs);
+  bottom: 0;
+  position: fixed;
+  z-index: 999;
+}
+
+.info {
+  display: flex;
+  align-items: center;
+  gap: 1ex;
+}
+
+.disableButton {
+  display: flex;
+  align-items: center;
+  padding: var(--size-spacing-3xs) var(--size-spacing-2xs);
+  border: 2px solid currentcolor;
+  border-radius: var(--size-spacing-2xs);
+  height: var(--size-spacing-s);
+}

--- a/components/organisms/PreviewMode/index.tsx
+++ b/components/organisms/PreviewMode/index.tsx
@@ -1,0 +1,18 @@
+import { draftMode } from "next/headers";
+import { FC, PropsWithChildren } from "react";
+import Banner from "./Banner";
+
+const PreviewMode: FC<PropsWithChildren> = ({ children }) => {
+  const { isEnabled } = draftMode();
+
+  return (
+    <>
+      {isEnabled && <Banner />}
+      {children}
+    </>
+  );
+};
+
+PreviewMode.displayName = "Organism.PreviewMode";
+
+export default PreviewMode;

--- a/components/templates/SlideshowPage/index.tsx
+++ b/components/templates/SlideshowPage/index.tsx
@@ -6,9 +6,8 @@ const SlideshowPage: FunctionComponent<{
   section: string;
   data: PageEntry;
   locale: string;
-  previewToken?: string;
-}> = async ({ data: { uri }, section, locale, previewToken }) => {
-  const data = await getSlideshowDataByUri(uri, locale, previewToken);
+}> = async ({ data: { uri }, section, locale }) => {
+  const data = await getSlideshowDataByUri(uri, locale);
 
   return <SlideshowPageClient {...{ data, section }} />;
 };

--- a/gql/gql.ts
+++ b/gql/gql.ts
@@ -14,6 +14,8 @@ import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-
  * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
  */
 const documents = {
+  "\n  query PagePreviewQuery($site: [String], $uri: [String]) {\n    entry(site: $site, uri: $uri) {\n      __typename\n      uri\n      title\n    }\n  }\n":
+    types.PagePreviewQueryDocument,
   '\n    query RecentAssetsQuery(\n      $site: [String]\n      $uri: [String]\n      $scheme: [String]\n    ) {\n      galleriesEntries(uri: $uri, site: $site) {\n        ... on galleries_gallery_Entry {\n          assetAlbum(whereIn: { key: "scheme", values: $scheme }) {\n            id\n          }\n        }\n      }\n    }\n  ':
     types.RecentAssetsQueryDocument,
   '\n    query GalleryTitleQuery(\n      $site: [String]\n      $uri: [String]\n      $id: String\n      $scheme: [String]\n    ) {\n      galleriesEntries(uri: $uri, site: $site) {\n        ... on galleries_gallery_Entry {\n          id\n          title\n          assetAlbum(\n            whereIn: { key: "scheme", values: $scheme }\n            where: { key: "id", value: $id }\n          ) {\n            additional {\n              TitleEN\n              TitleES\n            }\n            id\n            name\n          }\n        }\n      }\n    }\n  ':
@@ -54,6 +56,12 @@ const documents = {
  */
 export function graphql(source: string): unknown;
 
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: "\n  query PagePreviewQuery($site: [String], $uri: [String]) {\n    entry(site: $site, uri: $uri) {\n      __typename\n      uri\n      title\n    }\n  }\n"
+): (typeof documents)["\n  query PagePreviewQuery($site: [String], $uri: [String]) {\n    entry(site: $site, uri: $uri) {\n      __typename\n      uri\n      title\n    }\n  }\n"];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/lib/api/client/query.ts
+++ b/lib/api/client/query.ts
@@ -1,8 +1,10 @@
+"server-only";
 import { RequestInit } from "next/dist/server/web/spec-extension/request";
 import { createClient, fetchExchange } from "@urql/core";
 import { registerUrql } from "@urql/next/rsc";
 import type { AnyVariables, DocumentInput, OperationResult } from "@urql/core";
 import merge from "lodash/merge";
+import previewSession from "@/services/sessions/preview";
 
 let API_URL = process.env.NEXT_PUBLIC_API_URL as string;
 
@@ -28,10 +30,11 @@ const queryAPI = async <Query, Variables extends AnyVariables = AnyVariables>({
   fetchOptions?: RequestInit;
   previewToken?: string;
 }): Promise<OperationResult<Query, Variables>> => {
+  const token = previewToken || previewSession().token();
   const defaultFetchOptions: RequestInit = {
     cache: "force-cache",
     next: {
-      revalidate: previewToken ? 0 : undefined,
+      revalidate: token ? 0 : undefined,
     },
   };
   const fetchOptions = merge({}, defaultFetchOptions, inputFetchOptions);
@@ -42,8 +45,8 @@ const queryAPI = async <Query, Variables extends AnyVariables = AnyVariables>({
 
   const params = new URLSearchParams({});
 
-  if (previewToken) {
-    params.append("token", previewToken);
+  if (token) {
+    params.append("token", token);
   }
 
   const makeClient = () => {

--- a/lib/api/entries.js
+++ b/lib/api/entries.js
@@ -11,7 +11,7 @@ import { glossaryTermFragment } from "@/lib/api/fragments/glossary-term";
 import { studentPageFragment } from "./fragments/student-page";
 import { educatorPageFragment } from "./fragments/educator-page";
 import { investigationLandingPageFragment } from "./fragments/investigation-landing-page";
-import { galleryFragment } from "./galleries";
+import { galleryFragment } from "@/lib/api/fragments/galleries";
 
 function dataListQueryify(fragment) {
   return gql`

--- a/lib/api/entries/index.ts
+++ b/lib/api/entries/index.ts
@@ -26,11 +26,7 @@ export async function getEntriesByLocale(locale: string) {
   return data;
 }
 
-export async function getEntrySectionByUri(
-  uri = "__home__",
-  locale: string,
-  previewToken?: string
-) {
+export async function getEntrySectionByUri(uri = "__home__", locale: string) {
   const site = getSiteFromLocale(locale);
   const query = gql`
     query getEntrySectionByUri($site: [String], $uri: [String]) {
@@ -43,7 +39,6 @@ export async function getEntrySectionByUri(
   const { data } = await queryAPI({
     query,
     variables: { uri: decodeURI(uri), site },
-    previewToken,
   });
   return data.entry;
 }

--- a/lib/api/entry/index.ts
+++ b/lib/api/entry/index.ts
@@ -167,8 +167,7 @@ export async function getEntryDataByUri(
   uri: string,
   section: string,
   type: string,
-  locale: string,
-  previewToken?: string
+  locale: string
 ) {
   const site = getSiteFromLocale(locale);
   const query = getQueryFragments(uri, section, type, site);
@@ -181,7 +180,6 @@ export async function getEntryDataByUri(
       site,
       uri: decodeURI(uri),
     },
-    previewToken,
   });
 
   // Get the related investigation

--- a/lib/api/fragments/galleries.ts
+++ b/lib/api/fragments/galleries.ts
@@ -1,0 +1,22 @@
+import { fullBaseFields } from "../fragments/shared";
+
+export const galleryFragment = `
+  fragment galleryFragment on galleries_gallery_Entry {
+    ${fullBaseFields}
+    description
+    cantoAssetSingle {
+      metadata: additional {
+        AltTextEN
+        AltTextES
+        TitleEN
+        TitleES
+      }
+      height
+      url {
+        directUrlOriginal
+        directUrlPreview
+      }
+      width
+    }
+  }
+`;

--- a/lib/api/galleries/index.ts
+++ b/lib/api/galleries/index.ts
@@ -15,7 +15,6 @@ import {
   WhereInFiltersInput,
   WhereNotInFiltersInput,
 } from "@/gql/graphql";
-import { fullBaseFields } from "../fragments/shared";
 
 const whereIn = ({ tag = [] }: GalleryDataFilters): WhereInFiltersInput => {
   if (tag.length > 0) {
@@ -58,27 +57,6 @@ const whereNotIn = ({
 
   return { key: "scheme", values: unsupported };
 };
-
-export const galleryFragment = `
-  fragment galleryFragment on galleries_gallery_Entry {
-    ${fullBaseFields}
-    description
-    cantoAssetSingle {
-      metadata: additional {
-        AltTextEN
-        AltTextES
-        TitleEN
-        TitleES
-      }
-      height
-      url {
-        directUrlOriginal
-        directUrlPreview
-      }
-      width
-    }
-  }
-`;
 
 const imageAsset = z.object({
   altText: z.string().nullable(),

--- a/lib/api/homepage/index.ts
+++ b/lib/api/homepage/index.ts
@@ -9,7 +9,7 @@ import { getLinkFields, linkFragment } from "@/lib/api/fragments/link";
 import queryAPI from "@/lib/api/client/query";
 import { CRAFT_HOMEPAGE_URI } from "@/lib/constants";
 
-export const getHomepage = async (locale: string, previewToken?: string) => {
+export const getHomepage = async (locale: string) => {
   const site = getSiteFromLocale(locale);
 
   const query = gql`
@@ -76,16 +76,12 @@ export const getHomepage = async (locale: string, previewToken?: string) => {
   const { data } = await queryAPI({
     query,
     variables: { site, uri: CRAFT_HOMEPAGE_URI },
-    previewToken,
   });
 
   return data?.entry;
 };
 
-export const getHomepageMetadata = async (
-  locale: string,
-  previewToken?: string
-) => {
+export const getHomepageMetadata = async (locale: string) => {
   const site = getSiteFromLocale(locale);
 
   const query = gql`
@@ -102,7 +98,6 @@ export const getHomepageMetadata = async (
   const { data } = await queryAPI({
     query,
     variables: { site, uri: CRAFT_HOMEPAGE_URI },
-    previewToken,
   });
 
   return data;

--- a/lib/api/metadata/index.ts
+++ b/lib/api/metadata/index.ts
@@ -4,11 +4,7 @@ import { getSiteFromLocale } from "@/lib/helpers/site";
 import { fallbackLng } from "@/lib/i18n/settings";
 import { cantoSingleAsset, getImageFields } from "../fragments/image";
 
-export async function getEntryMetadataByUri(
-  uri: string,
-  locale = fallbackLng,
-  previewToken?: string
-) {
+export async function getEntryMetadataByUri(uri: string, locale = fallbackLng) {
   const site = getSiteFromLocale(locale);
 
   const query = gql`
@@ -93,17 +89,12 @@ export async function getEntryMetadataByUri(
   const { data } = await queryAPI({
     query,
     variables: { site, uri: decodeURI(uri) },
-    previewToken,
   });
 
   return data;
 }
 
-export async function getBreadcrumbsById(
-  id: number,
-  locale: string,
-  previewToken?: string
-) {
+export async function getBreadcrumbsById(id: number, locale: string) {
   if (!id) return null;
   const site = getSiteFromLocale(locale);
 
@@ -119,7 +110,6 @@ export async function getBreadcrumbsById(
   const { data } = await queryAPI({
     query,
     variables: { site, id },
-    previewToken,
   });
   return data.entries;
 }

--- a/lib/api/search/index.ts
+++ b/lib/api/search/index.ts
@@ -2,7 +2,7 @@ import { graphql } from "@/gql/gql";
 import queryAPI from "@/lib/api/client/query";
 import { getSiteFromLocale } from "@/lib/helpers/site";
 
-export async function getSearchPage(locale: string, previewToken?: string) {
+export async function getSearchPage(locale: string) {
   const site = getSiteFromLocale(locale);
   const query = graphql(`
     query SearchResultsPage($site: [String]) {
@@ -16,7 +16,7 @@ export async function getSearchPage(locale: string, previewToken?: string) {
     }
   `);
 
-  const { data } = await queryAPI({ query, variables: { site }, previewToken });
+  const { data } = await queryAPI({ query, variables: { site } });
 
   if (!data) return;
 

--- a/lib/api/slideshows/index.ts
+++ b/lib/api/slideshows/index.ts
@@ -4,11 +4,7 @@ import { slideshowFragment } from "@/lib/api/fragments/slideshow";
 import { getImageFields } from "@/lib/api/fragments/image";
 import { getSiteFromLocale } from "@/lib/helpers/site";
 
-export async function getSlideshowDataByUri(
-  uri: string,
-  locale: string,
-  previewToken?: string
-) {
+export async function getSlideshowDataByUri(uri: string, locale: string) {
   const site = getSiteFromLocale(locale);
   const query = gql`
     ${slideshowFragment}
@@ -42,7 +38,6 @@ export async function getSlideshowDataByUri(
   const { data } = await queryAPI({
     query,
     variables: { uri, site },
-    previewToken,
   });
 
   return data;

--- a/lib/i18n/localeStrings/en/translation.json
+++ b/lib/i18n/localeStrings/en/translation.json
@@ -458,5 +458,9 @@
         "shutter_speed": "Camera shutter speed"
       }
     }
+  },
+  "preview_mode": {
+    "is_enabled": "Preview mode is enabled",
+    "disable": "Disable"
   }
 }

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "react-popper": "^2.3.0",
     "sanitize-html": "^2.13.1",
     "schema-dts": "^1.1.2",
+    "server-only": "^0.0.1",
     "sharp": "^0.33.5",
     "striptags": "^3.2.0",
     "styled-components": "^6.1.1",

--- a/services/actions/endPreviewMode.ts
+++ b/services/actions/endPreviewMode.ts
@@ -1,0 +1,9 @@
+"use server";
+
+import previewSession from "@/services/sessions/preview";
+
+async function endPreviewMode() {
+  previewSession().end();
+}
+
+export default endPreviewMode;

--- a/services/sessions/preview.ts
+++ b/services/sessions/preview.ts
@@ -1,0 +1,40 @@
+import { ResponseCookie } from "next/dist/compiled/@edge-runtime/cookies";
+import { cookies, draftMode } from "next/headers";
+
+const previewSession = () => {
+  const cookieSettings: Partial<ResponseCookie> = {
+    httpOnly: true,
+    sameSite: true,
+    secure: true,
+  };
+  const tokenCookie = "previewToken";
+
+  const draft = () => {
+    try {
+      return draftMode().isEnabled;
+    } catch {
+      return false;
+    }
+  };
+
+  const start = ({ previewToken }: { previewToken?: string }) => {
+    draftMode().enable();
+
+    if (previewToken) {
+      cookies().set(tokenCookie, previewToken, cookieSettings);
+    }
+  };
+  const end = () => {
+    draftMode().disable();
+    cookies().delete(tokenCookie);
+  };
+  const token = () => {
+    if (draft()) {
+      return cookies().get(tokenCookie)?.value;
+    }
+  };
+
+  return { start, end, token };
+};
+
+export default previewSession;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,7 +42,8 @@
       "@/helpers": ["helpers"],
       "@/helpers/*": ["helpers/*"],
       "@/hoc/*": ["components/hoc/*"],
-      "@/gql/*": ["gql/*"]
+      "@/gql/*": ["gql/*"],
+      "@/services/*": ["services/*"]
     },
     "types": ["cypress", "node"]
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11740,7 +11740,7 @@ picocolors@^1.0.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
-picocolors@^1.1.1:
+picocolors@^1.1.0, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
@@ -13283,6 +13283,11 @@ serve-static@1.15.0:
     parseurl "~1.3.3"
     send "0.18.0"
 
+server-only@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/server-only/-/server-only-0.0.1.tgz#0f366bb6afb618c37c9255a314535dc412cd1c9e"
+  integrity sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==
+
 set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -13653,16 +13658,12 @@ string-argv@^0.3.1:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
   integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
+string-env-interpolation@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/string-env-interpolation/-/string-env-interpolation-1.0.1.tgz#ad4397ae4ac53fe6c91d1402ad6f6a52862c7152"
+  integrity sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg==
 
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -13809,7 +13810,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -13829,13 +13830,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.0.1"
@@ -15099,7 +15093,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -15121,15 +15115,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Resolves #708 

Instead of manually affixing the Craft preview token to the search params, the token is committed to a session cookie which is automatically appended by the GraphQL client on queries. 

Since both Next draftMode and the preview token cookies are session cookies, they are not cleared until the browser is closed. To avoid getting stuck in preview mode, a banner is shown indicating preview mode with a button to disable it.

Testing
- Check out a live preview in Craft like a page, gallery, or news article
- Check out the non-live preview ("View") and see that the preview mode banner appears
- Click "disable" on the preview mode banner and see that any draft changes disappear

Does the language on the banner make sense? Would "Exit" be a better CTA on the button?