### PR TITLE
fix: csrf + noindex for gallery downloads

### DIFF
--- a/app/api/canto/[scheme]/[id]/[directUrlOriginalHash]/route.ts
+++ b/app/api/canto/[scheme]/[id]/[directUrlOriginalHash]/route.ts
@@ -4,6 +4,7 @@ import {
   SupportedCantoAssetScheme,
   SupportedCantoScheme,
 } from "@/lib/api/galleries/schema";
+import { headers } from "next/headers";
 
 type CantoAssetParams = {
   scheme: SupportedCantoAssetScheme;
@@ -19,6 +20,19 @@ export async function GET(
   request: NextRequest,
   { params: { scheme, id, directUrlOriginalHash } }: CantoDownloadProps
 ) {
+  const headersList = headers();
+  const referer = headersList.get("referer");
+
+  if (!referer) {
+    return new NextResponse("Invalid client", { status: 403 });
+  }
+
+  const { origin } = new URL(referer);
+
+  if (process.env.NEXT_PUBLIC_BASE_URL !== origin) {
+    return new NextResponse("Invalid client", { status: 403 });
+  }
+
   const { error } = SupportedCantoScheme.safeParse(scheme);
 
   if (error) {
@@ -62,6 +76,7 @@ export async function GET(
         "last-modified",
       ]),
       "content-disposition": `attachment; filename="${fileName}"`,
+      "X-Robots-Tag": "noindex",
     });
 
     return new NextResponse(body, {


### PR DESCRIPTION
Prohibit downloads that are not from the same origin, add "noindex" headers to image responses. 