### PR TITLE
feat: content block for Skyviewer

### DIFF
--- a/components/EventTime/patterns/EventTimeLong.js
+++ b/components/EventTime/patterns/EventTimeLong.js
@@ -1,3 +1,4 @@
+"use client";
 import PropTypes from "prop-types";
 import { useTimeString, useTimeZone } from "@/lib/utils";
 import { makeDateString } from "@/helpers/dates";

--- a/components/EventTime/patterns/EventTimeShort/index.js
+++ b/components/EventTime/patterns/EventTimeShort/index.js
@@ -1,3 +1,4 @@
+"use client";
 import PropTypes from "prop-types";
 import { useGlobalData } from "@/lib/utils";
 import { makeDateObject } from "@/helpers/dates";

--- a/components/atomic/RichTextContent/RichTextContent.cy.tsx
+++ b/components/atomic/RichTextContent/RichTextContent.cy.tsx
@@ -1,0 +1,29 @@
+import RichTextContent from "./index";
+import striptags from "striptags";
+import { mount } from "cypress/react18";
+
+const props = {
+  text: "<p>My text <strong>here</strong></p><p>Another line here</p>",
+};
+const selector = "[data-cy=rich-text-content]";
+
+describe("<RichTextContent>", () => {
+  it("exists", () => {
+    mount(<RichTextContent {...props} />);
+    cy.get(selector).should("exist");
+  });
+  it("embeds rich text content", () => {
+    mount(<RichTextContent {...props} />);
+    cy.get(selector).should((e) => {
+      expect(e).to.contain(striptags(props.text));
+      expect(e.children()).to.have.length(2);
+    });
+  });
+  it("passes additional HTML attribute props", () => {
+    const id = "myTextContent";
+    mount(<RichTextContent id={id} {...props} />);
+    cy.get(selector).should((e) => {
+      expect(e).to.have.attr("id", id);
+    });
+  });
+});

--- a/components/atomic/RichTextContent/index.tsx
+++ b/components/atomic/RichTextContent/index.tsx
@@ -1,0 +1,26 @@
+import { ComponentProps, FC } from "react";
+import classNames from "classnames";
+import styles from "./styles.module.css";
+
+interface RichTextContentProps extends ComponentProps<"div"> {
+  text: string;
+}
+
+const RichTextContent: FC<RichTextContentProps> = ({
+  className,
+  text,
+  ...props
+}) => {
+  return (
+    <div
+      {...props}
+      data-cy="rich-text-content"
+      className={classNames(styles.contentRte, className)}
+      dangerouslySetInnerHTML={{ __html: text }}
+    />
+  );
+};
+
+RichTextContent.displayName = "Atom.RichTextContent";
+
+export default RichTextContent;

--- a/components/atomic/RichTextContent/styles.module.css
+++ b/components/atomic/RichTextContent/styles.module.css
@@ -1,0 +1,46 @@
+.contentRte {
+  & > * + * {
+    margin-block-start: var(--size-spacing-s);
+  }
+
+  & > *:first-child {
+    margin-block-start: 0;
+  }
+
+  & a:not([class^="c-"]) {
+    color: var(--link-color, var(--turquoise80));
+    text-decoration: underline;
+  }
+
+  & ul {
+    padding-left: var(--size-spacing-s);
+    list-style-type: disc;
+  }
+
+  & ol {
+    padding-left: var(--size-spacing-s);
+    list-style-type: decimal;
+  }
+
+  & li {
+    padding-left: var(--size-spacing-2xs);
+  }
+
+  & h1 {
+    margin-block-start: var(--size-spacing-4xl);
+  }
+
+  & h2 {
+    margin-block-start: var(--size-spacing-l);
+  }
+
+  & h3,
+  & h4 {
+    margin-block-start: var(--size-spacing-s);
+  }
+
+  & figcaption {
+    padding-block: var(--size-spacing-s);
+    font-size: 18px;
+  }
+}

--- a/components/content-blocks/ContactStaff/index.js
+++ b/components/content-blocks/ContactStaff/index.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import styled from "styled-components";
 import Container from "@rubin-epo/epo-react-lib/Container";
 import { useTranslation } from "react-i18next";
-import { createLocationString } from "@/lib/utils";
+import { createLocationString } from "@/lib/helpers/location";
 
 export default function ContactStaff({ header, staffEntry }) {
   const { t } = useTranslation();

--- a/components/content-blocks/Skyviewer/index.tsx
+++ b/components/content-blocks/Skyviewer/index.tsx
@@ -1,0 +1,102 @@
+import { FC } from "react";
+import { z } from "zod";
+import Container from "@rubin-epo/epo-react-lib/Container";
+import Figure from "@rubin-epo/epo-react-lib/Figure";
+import { env } from "@/env";
+import { FragmentType, useFragment } from "@/gql";
+import { SkyviewerBlockFragmentDoc } from "@/gql/graphql";
+import { addLocaleUriSegment } from "@/lib/i18n";
+import RichTextContent from "@/components/atomic/RichTextContent";
+import styles from "./styles.module.css";
+
+const skyviewerDefaultsSchema = z.object({
+  embedTitle: z.string(),
+  ra: z
+    .number()
+    .min(0)
+    .max(360)
+    .transform((v) => v?.toString())
+    .catch(""),
+  dec: z
+    .number()
+    .min(-90)
+    .max(90)
+    .transform((v) => v?.toString())
+    .catch(""),
+  fov: z
+    .number()
+    .min(0)
+    .transform((v) => v?.toString())
+    .catch(""),
+  backgroundColor: z.string().optional().catch(undefined),
+  fullWidth: z.boolean().catch(false),
+});
+
+interface SkyviewerProps
+  extends FragmentType<typeof SkyviewerBlockFragmentDoc> {
+  locale: string;
+}
+
+const SkyviewerBlock: FC<SkyviewerProps> = ({ locale, ...props }) => {
+  const { captionRichText, ...parseAble } = useFragment(
+    SkyviewerBlockFragmentDoc,
+    props
+  );
+  const { data, error } = skyviewerDefaultsSchema.safeParse(parseAble);
+
+  if (error) {
+    console.warn(error.issues[0].message);
+    return null;
+  }
+
+  const { ra, dec, fov, fullWidth, backgroundColor, embedTitle } = data;
+
+  const params = new URLSearchParams({ ra, dec, fov });
+  const path = addLocaleUriSegment(locale, `embed?${params.toString()}`);
+  const src = new URL(`${env.SKYVIEWER_BASE_URL}${path}`);
+  const allowed = ["fullscreen", "clipboard-write", "clipboard-read"].join(
+    "; "
+  );
+  const sandbox = [
+    "allow-downloads",
+    "allow-scripts",
+    "allow-popups",
+    "allow-popups-to-escape-sandbox",
+    "allow-same-origin",
+  ].join(" ");
+
+  const iframe = (
+    <iframe
+      data-cy="skyviewer"
+      title={embedTitle}
+      className={styles.iframe}
+      data-embed={!fullWidth}
+      src={src.href}
+      allow={allowed}
+      sandbox={sandbox}
+      loading={fullWidth ? "eager" : "lazy"}
+    />
+  );
+
+  const caption = captionRichText && <RichTextContent text={captionRichText} />;
+
+  return fullWidth ? (
+    <section
+      className={styles.container}
+      style={{ backgroundColor: backgroundColor && `--${backgroundColor}` }}
+    >
+      {iframe}
+      {caption}
+    </section>
+  ) : (
+    <Container paddingSize="small">
+      <Figure caption={caption} withBackground>
+        {iframe}
+      </Figure>
+    </Container>
+  );
+};
+
+SkyviewerBlock.displayName = "ContentBlock.Skyviewer";
+
+export default SkyviewerBlock;

--- a/components/content-blocks/Skyviewer/styles.module.css
+++ b/components/content-blocks/Skyviewer/styles.module.css
@@ -1,0 +1,24 @@
+.container {
+  padding: var(--size-spacing-xs);
+}
+
+.iframe {
+  aspect-ratio: var(--ratio-iframe-size, 1880 / 1027);
+  border: none;
+  display: block;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+
+  @media (--portrait) {
+    --ratio-iframe-size: 290 / 366;
+  }
+
+  &[data-embed="true"] {
+    --ratio-iframe-size: 750 / 580;
+
+    @media (--portrait) {
+      --ratio-iframe-size: 260 / 366;
+    }
+  }
+}

--- a/components/dynamic/EventList/index.js
+++ b/components/dynamic/EventList/index.js
@@ -1,10 +1,12 @@
+"use client";
 import PropTypes from "prop-types";
 import { useTranslation } from "react-i18next";
 import { Grid, IconComposer } from "@rubin-epo/epo-react-lib";
 import DataList from "@/dynamic/DataList";
 import Tile from "@/atomic/Tile";
 import EventTime from "@/components/EventTime";
-import { checkIfBetweenDates, createLocationString } from "@/lib/utils";
+import { checkIfBetweenDates } from "@/lib/utils/dates";
+import { createLocationString } from "@/lib/helpers/location";
 import * as Styled from "./styles";
 
 const EventList = ({

--- a/components/dynamic/JobList/index.js
+++ b/components/dynamic/JobList/index.js
@@ -3,7 +3,8 @@ import { useTranslation } from "react-i18next";
 import { Grid, IconComposer } from "@rubin-epo/epo-react-lib";
 import DataList from "@/dynamic/DataList";
 import Tile from "@/atomic/Tile";
-import { checkIfBetweenDates, createLocationString } from "@/lib/utils";
+import { checkIfBetweenDates } from "@/lib/utils/dates";
+import { createLocationString } from "@/lib/helpers/location";
 import * as Styled from "./styles";
 
 const JobList = ({

--- a/components/dynamic/StaffList/index.js
+++ b/components/dynamic/StaffList/index.js
@@ -1,3 +1,4 @@
+"use client";
 import PropTypes from "prop-types";
 import { useTranslation } from "react-i18next";
 import { Grid } from "@rubin-epo/epo-react-lib";

--- a/components/factories/ContentBlockFactory.js
+++ b/components/factories/ContentBlockFactory.js
@@ -1,3 +1,4 @@
+"server-only";
 import PropTypes from "prop-types";
 import {
   Image,
@@ -22,6 +23,8 @@ import {
   PeopleBlock,
   KeyNumbersGridBlock,
 } from "@/content-blocks";
+import SkyviewerBlock from "@/components/content-blocks/Skyviewer";
+import { getLocale } from "@/lib/i18n/server";
 
 const blockMap = {
   accordionGroup: AccordionGroup,
@@ -51,12 +54,14 @@ const blockMap = {
   publicationsList: PublicationsList,
   peopleBlock: PeopleBlock,
   keyNumbersGrid: KeyNumbersGridBlock,
+  skyviewer: SkyviewerBlock,
 };
 
 export default function ContentBlockFactory({ type, data, pageId }) {
+  const locale = getLocale();
   const Block = blockMap[type];
   if (!Block) return null;
-  return <Block {...data} pageId={pageId} />;
+  return <Block {...data} pageId={pageId} locale={locale} />;
 }
 
 ContentBlockFactory.propTypes = {

--- a/components/templates/EventPage/index.js
+++ b/components/templates/EventPage/index.js
@@ -1,11 +1,10 @@
-"use client";
 import PropTypes from "prop-types";
-import { useTranslation } from "react-i18next";
-import {
-  checkIfBetweenDates,
-  createLocationString,
-  useCustomBreadcrumbs,
-} from "@/lib/utils";
+import getRootPages from "@/services/craft/globals/rootPages";
+import { getLocale } from "@/lib/i18n/server";
+import { createLocationString } from "@/lib/helpers/location";
+import { checkIfBetweenDates } from "@/lib/utils/dates";
+import { getCustomBreadcrumbs } from "@/lib/helpers/breadcrumbs";
+import { useTranslation } from "@/lib/i18n";
 import Hero from "@/components/molecules/Hero";
 import ContentBlockFactory from "@/factories/ContentBlockFactory";
 import { Share } from "@/content-blocks";
@@ -15,7 +14,7 @@ import EventList from "@/dynamic/EventList";
 import EventTime from "@/components/EventTime";
 import * as Styled from "./styles";
 
-export default function EventPage({
+export default async function EventPage({
   data: {
     address,
     city,
@@ -39,8 +38,12 @@ export default function EventPage({
     uri,
   },
 }) {
-  const { t } = useTranslation();
-  const customBreadcrumbs = useCustomBreadcrumbs("Events");
+  const { t } = await useTranslation(getLocale());
+  const rootPages = await getRootPages();
+  const customBreadcrumbs = getCustomBreadcrumbs({
+    rootPages,
+    header: "Events",
+  });
   const rootHomeLink = customBreadcrumbs.slice(-1)[0];
 
   const pageLink = {

--- a/components/templates/EventPage/styles.js
+++ b/components/templates/EventPage/styles.js
@@ -1,3 +1,4 @@
+"use client";
 import styled from "styled-components";
 
 export const Pretitle = styled.div`

--- a/components/templates/NewsPage/Contacts/index.tsx
+++ b/components/templates/NewsPage/Contacts/index.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { FunctionComponent } from "react";
 import { useTranslation } from "react-i18next";
 import { ReleaseContact } from "@/services/noirlab";

--- a/components/templates/NewsPage/NewsArticle.js
+++ b/components/templates/NewsPage/NewsArticle.js
@@ -1,15 +1,14 @@
-"use client";
 import PropTypes from "prop-types";
-import { useTranslation } from "react-i18next";
-import useResizeObserver from "use-resize-observer";
+import { useTranslation } from "@/lib/i18n";
 import { makeDateString } from "@/helpers/dates";
 import ContentBlockFactory from "@/factories/ContentBlockFactory";
 import Container from "@rubin-epo/epo-react-lib/Container";
 import { Share } from "@/content-blocks";
 import Contacts from "./Contacts";
 import * as Styled from "./styles";
+import { getLocale } from "@/lib/i18n/server";
 
-export default function NewsArticle({ data }) {
+export default async function NewsArticle({ data }) {
   const {
     contentBlocksNews = [],
     date,
@@ -30,17 +29,8 @@ export default function NewsArticle({ data }) {
   const {
     t,
     i18n: { resolvedLanguage },
-  } = useTranslation();
+  } = await useTranslation(getLocale());
   const localizedDate = makeDateString(date, { locale: resolvedLanguage });
-  const { ref } = useResizeObserver({
-    box: "border-box",
-    onResize: ({ height }) => {
-      document.documentElement.style.setProperty(
-        "--Hero-caption-offset",
-        `-${height}px`
-      );
-    },
-  });
 
   return (
     <Styled.Article>
@@ -48,7 +38,6 @@ export default function NewsArticle({ data }) {
         <div>
           {heroCaption && (
             <Styled.HeroCaption
-              ref={ref}
               dangerouslySetInnerHTML={{ __html: heroCaption }}
               aria-hidden
             />

--- a/components/templates/NewsPage/styles.js
+++ b/components/templates/NewsPage/styles.js
@@ -33,11 +33,11 @@ export const HeroCaption = styled.div`
 
 export const Article = styled.article`
   z-index: 1;
-  margin-top: var(--Hero-caption-offset);
+  margin-block-start: calc(var(--size-spacing-l) * -1);
   background-color: white;
 
   @media (max-width: ${tokens.BREAK_TABLET}) {
-    margin-top: auto;
+    margin-block-start: auto;
   }
 `;
 

--- a/components/templates/StaffPage/index.js
+++ b/components/templates/StaffPage/index.js
@@ -1,8 +1,7 @@
-"use client";
 import PropTypes from "prop-types";
-import { useTranslation } from "react-i18next";
-import { useGlobalData } from "@/lib/utils";
-import { addLocaleUriSegment } from "@/lib/i18n";
+import { getLocale } from "@/lib/i18n/server";
+import { addLocaleUriSegment, useTranslation } from "@/lib/i18n";
+import getRootPages from "@/services/craft/globals/rootPages";
 import { Share } from "@/content-blocks";
 import StaffList from "@/dynamic/StaffList";
 import ContentBlockFactory from "@/factories/ContentBlockFactory";
@@ -27,7 +26,7 @@ function getParentEntry(rootPages) {
   return parentRootPage?.pageEntry?.[0];
 }
 
-export default function StaffPage({
+export default async function StaffPage({
   data: {
     id,
     uri,
@@ -43,8 +42,8 @@ export default function StaffPage({
   const {
     t,
     i18n: { language },
-  } = useTranslation();
-  const rootPages = useGlobalData("rootPages");
+  } = await useTranslation(getLocale());
+  const rootPages = await getRootPages();
   const parentUri = getParentUri(uri);
   const parentEntry = getParentEntry(rootPages);
 

--- a/components/templates/StaffPage/styles.js
+++ b/components/templates/StaffPage/styles.js
@@ -1,3 +1,4 @@
+"use client";
 import styled from "styled-components";
 import { fluidScale, respond, containerRegular } from "@/styles/globalStyles";
 import AsideSection from "@/components/molecules/Aside/Section";

--- a/env.ts
+++ b/env.ts
@@ -13,6 +13,7 @@ export const env = createEnv({
     CRAFT_REVALIDATE_SECRET_TOKEN: z.string().min(1),
     CRAFT_SECRET_TOKEN: z.string().min(1),
     GOOGLE_APP_SECRET: z.string().min(1),
+    SKYVIEWER_BASE_URL: z.string().url(),
   },
   client: {
     NEXT_PUBLIC_API_URL: z.string().url(),

--- a/gql/gql.ts
+++ b/gql/gql.ts
@@ -44,8 +44,16 @@ const documents = {
     types.GetNavigationItemsDocument,
   "\n    query SearchResultsPage($site: [String]) {\n      searchResultsEntries(site: $site) {\n        ... on searchResults_searchResults_Entry {\n          title\n          id\n          dynamicComponent\n        }\n      }\n    }\n  ":
     types.SearchResultsPageDocument,
+  "\n  fragment skyviewerBlock on contentBlocks_skyviewer_BlockType {\n    id\n    embedTitle\n    typeHandle\n    captionRichText\n    dec\n    fov\n    ra\n    fullWidth\n    backgroundColor\n  }\n":
+    types.SkyviewerBlockFragmentDoc,
+  "\n  fragment skyviewerNewsBlock on contentBlocksNews_skyviewer_BlockType {\n    id\n    embedTitle\n    typeHandle\n    captionRichText\n    dec\n    fov\n    ra\n    fullWidth\n    backgroundColor\n  }\n":
+    types.SkyviewerNewsBlockFragmentDoc,
   "\n    query getLogos($set: [String], $site: [String]) {\n      siteInfo: globalSet(handle: $set, site: $site) {\n        ... on siteInfo_GlobalSet {\n          __typename\n          logoLarge {\n            url {\n              directUrlOriginal\n            }\n            width\n            height\n          }\n          logoSmall {\n            url {\n              directUrlOriginal\n            }\n            width\n            height\n          }\n        }\n      }\n    }\n  ":
     types.GetLogosDocument,
+  "\n  fragment rootPageInfoFragment on rootPageInformation_GlobalSet {\n    name\n    handle\n    customBreadcrumbs {\n      ... on customBreadcrumbs_ancestorsAndRoot_BlockType {\n        header\n        pageEntry {\n          id\n          title\n          uri\n        }\n      }\n    }\n  }\n":
+    types.RootPageInfoFragmentFragmentDoc,
+  "\n    query getRootPages($site: [String], $set: [String]) {\n      rootPages: globalSet(handle: $set, site: $site) {\n        ...rootPageInfoFragment\n      }\n    }\n  ":
+    types.GetRootPagesDocument,
   '\n    query RelatedInvestigation($site: [String], $ids: [QueryArgument]) {\n      investigation: entry(type: "investigation", landingPage: $ids, site: $site) {\n        sectionHandle\n        ... on investigations_investigation_Entry {\n          uri\n          title\n          duration: plainText\n          typeHandle\n          externalUrl: externalUrlTranslatable\n          status: investigationStatus\n          landingPage {\n            ... on pages_investigationLandingPage_Entry {\n              id\n              uri\n              title\n            }\n          }\n          \n        }\n      }\n    }\n  ':
     types.RelatedInvestigationDocument,
   '\n    query GetSiblings(\n      $uri: [String]\n      $site: [String]\n      $parentId: Int\n      $level: Int\n    ) {\n      siblings: entry(uri: $uri, site: $site) {\n        prev(\n          descendantOf: $parentId\n          section: "pages"\n          site: $site\n          level: $level\n        ) {\n          uri\n          title\n        }\n        next(\n          descendantOf: $parentId\n          section: "pages"\n          site: $site\n          level: $level\n        ) {\n          uri\n          title\n        }\n      }\n    }\n  ':
@@ -160,8 +168,32 @@ export function graphql(
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
+  source: "\n  fragment skyviewerBlock on contentBlocks_skyviewer_BlockType {\n    id\n    embedTitle\n    typeHandle\n    captionRichText\n    dec\n    fov\n    ra\n    fullWidth\n    backgroundColor\n  }\n"
+): (typeof documents)["\n  fragment skyviewerBlock on contentBlocks_skyviewer_BlockType {\n    id\n    embedTitle\n    typeHandle\n    captionRichText\n    dec\n    fov\n    ra\n    fullWidth\n    backgroundColor\n  }\n"];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: "\n  fragment skyviewerNewsBlock on contentBlocksNews_skyviewer_BlockType {\n    id\n    embedTitle\n    typeHandle\n    captionRichText\n    dec\n    fov\n    ra\n    fullWidth\n    backgroundColor\n  }\n"
+): (typeof documents)["\n  fragment skyviewerNewsBlock on contentBlocksNews_skyviewer_BlockType {\n    id\n    embedTitle\n    typeHandle\n    captionRichText\n    dec\n    fov\n    ra\n    fullWidth\n    backgroundColor\n  }\n"];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
   source: "\n    query getLogos($set: [String], $site: [String]) {\n      siteInfo: globalSet(handle: $set, site: $site) {\n        ... on siteInfo_GlobalSet {\n          __typename\n          logoLarge {\n            url {\n              directUrlOriginal\n            }\n            width\n            height\n          }\n          logoSmall {\n            url {\n              directUrlOriginal\n            }\n            width\n            height\n          }\n        }\n      }\n    }\n  "
 ): (typeof documents)["\n    query getLogos($set: [String], $site: [String]) {\n      siteInfo: globalSet(handle: $set, site: $site) {\n        ... on siteInfo_GlobalSet {\n          __typename\n          logoLarge {\n            url {\n              directUrlOriginal\n            }\n            width\n            height\n          }\n          logoSmall {\n            url {\n              directUrlOriginal\n            }\n            width\n            height\n          }\n        }\n      }\n    }\n  "];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: "\n  fragment rootPageInfoFragment on rootPageInformation_GlobalSet {\n    name\n    handle\n    customBreadcrumbs {\n      ... on customBreadcrumbs_ancestorsAndRoot_BlockType {\n        header\n        pageEntry {\n          id\n          title\n          uri\n        }\n      }\n    }\n  }\n"
+): (typeof documents)["\n  fragment rootPageInfoFragment on rootPageInformation_GlobalSet {\n    name\n    handle\n    customBreadcrumbs {\n      ... on customBreadcrumbs_ancestorsAndRoot_BlockType {\n        header\n        pageEntry {\n          id\n          title\n          uri\n        }\n      }\n    }\n  }\n"];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: "\n    query getRootPages($site: [String], $set: [String]) {\n      rootPages: globalSet(handle: $set, site: $site) {\n        ...rootPageInfoFragment\n      }\n    }\n  "
+): (typeof documents)["\n    query getRootPages($site: [String], $set: [String]) {\n      rootPages: globalSet(handle: $set, site: $site) {\n        ...rootPageInfoFragment\n      }\n    }\n  "];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/lib/api/fragments/content-blocks.js
+++ b/lib/api/fragments/content-blocks.js
@@ -1,5 +1,10 @@
 import { getImageFields, cantoSingleAsset } from "@/api/fragments/image";
 import { getLinkFields } from "@/api/fragments/link";
+import { print } from "graphql";
+import {
+  SkyviewerBlockFragmentDoc,
+  SkyviewerNewsBlockFragmentDoc,
+} from "@/gql/graphql";
 
 /// ///////////////////////////////////////////
 ///   Page Content Blocks
@@ -642,6 +647,8 @@ export const keyNumbersBlockFragment = `
   }
 `;
 
+export const skyviewerBlockFragment = print(SkyviewerBlockFragmentDoc);
+
 export const allPageBlocksFragment = `
 ${accordionGroupBlockFragment}
 ${calloutBlockFragment}
@@ -668,6 +675,7 @@ ${summitStatusBlockFragment}
 ${publicationsListBlockFragment}
 ${peopleBlockFragment}
 ${keyNumbersBlockFragment}
+${skyviewerBlockFragment}
 `;
 
 export const allPageBlocks = `
@@ -696,6 +704,7 @@ export const allPageBlocks = `
   ...publicationsListBlock
   ...peopleBlock
   ...keyNumbersBlock
+  ...skyviewerBlock
 `;
 
 /// ///////////////////////////////////////////
@@ -815,6 +824,8 @@ export const videoBlockNewsFragment = `
   }
 `;
 
+export const skyviewerBlockNewsFragment = print(SkyviewerNewsBlockFragmentDoc);
+
 export const allNewsBlocksFragment = `
   ${textBlockNewsFragment}
   ${imageBlockNewsFragment}
@@ -822,6 +833,7 @@ export const allNewsBlocksFragment = `
   ${contactBlockNewsFragment}
   ${relatedContentNewsFragment}
   ${videoBlockNewsFragment}
+  ${skyviewerBlockNewsFragment}
 `;
 
 export const allNewsBlocks = `
@@ -831,10 +843,5 @@ export const allNewsBlocks = `
   ...contactBlockNews
   ...relatedContentBlockNews
   ...videoBlockNews
+  ...skyviewerNewsBlock
 `;
-
-/// ///////////////////////////////////////////
-///   Staff Profiles Content Blocks
-/// ///////////////////////////////////////////
-
-// Same as News (for now)

--- a/lib/api/fragments/global.js
+++ b/lib/api/fragments/global.js
@@ -52,23 +52,6 @@ fragment footerFragment on footer_GlobalSet {
 }
 `;
 
-export const rootPageInfoFragment = `
-fragment rootPageInfoFragment on rootPageInformation_GlobalSet {
-    name
-    handle
-    customBreadcrumbs {
-      ... on customBreadcrumbs_ancestorsAndRoot_BlockType {
-        header
-        pageEntry {
-          id
-          title
-          uri
-        }
-      }
-    }
-  }
-`;
-
 export const contactFormFragment = `
 fragment contactFormFragment on contactForm_GlobalSet {
   id

--- a/lib/api/globals/index.ts
+++ b/lib/api/globals/index.ts
@@ -1,11 +1,12 @@
 import { gql } from "@urql/core";
+import { print } from "graphql";
+import { RootPageInfoFragmentFragmentDoc } from "@/gql/graphql";
 import { fallbackLng } from "@/lib/i18n/settings";
 import queryAPI from "@/lib/api/client/query";
 import { linkFragment } from "@/lib/api/fragments/link";
 import {
   siteInfoFragment,
   footerFragment,
-  rootPageInfoFragment,
   contactFormFragment,
 } from "@/lib/api/fragments/global";
 import { categoriesFragment } from "@/lib/api/fragments/categories";
@@ -18,7 +19,7 @@ export async function getGlobalData(locale = fallbackLng) {
     ${linkFragment}
     ${siteInfoFragment}
     ${footerFragment}
-    ${rootPageInfoFragment}
+    ${print(RootPageInfoFragmentFragmentDoc)}
     ${contactFormFragment}
     ${categoriesFragment}
     query getGlobalData($site: [String]) {

--- a/lib/helpers/breadcrumbs.ts
+++ b/lib/helpers/breadcrumbs.ts
@@ -1,0 +1,15 @@
+import getRootPages from "@/services/craft/globals/rootPages";
+
+export const getCustomBreadcrumbs = ({
+  header,
+  rootPages = [],
+}: {
+  rootPages: Awaited<ReturnType<typeof getRootPages>>;
+  header: string;
+}) => {
+  const customBreadcrumbs = rootPages
+    ?.filter((p) => p && p.header?.includes(header))
+    .map((p) => p?.pageEntry);
+
+  return customBreadcrumbs ? customBreadcrumbs.flat(1) : undefined;
+};

--- a/lib/helpers/location.ts
+++ b/lib/helpers/location.ts
@@ -1,0 +1,21 @@
+export const createLocationString = (
+  city: string,
+  state: string,
+  country: string,
+  address = "",
+  isFull = false
+) => {
+  // logic for displaying city/state in US, city/country outside
+  let start: string = "";
+  let end: string;
+
+  if (isFull) {
+    start = address ? address + ", " : "";
+    end = state ? state + ", " + country : country;
+  } else {
+    end = country === "USA" || country === "United States" ? state : country;
+  }
+
+  const loc = `${start}${city ? city + ", " : ""}${end || ""}`;
+  return loc;
+};

--- a/lib/i18n/server.ts
+++ b/lib/i18n/server.ts
@@ -1,3 +1,4 @@
+"server-only";
 import { cache } from "react";
 import { cookies, headers } from "next/headers";
 import { cookieName, fallbackLng } from "./settings";

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,6 +6,7 @@ import { useFilterParams } from "@/contexts/FilterParams";
 import { fallbackLng } from "./i18n/settings";
 import { usePathname } from "next/navigation";
 import { getOffset, getIsFirstPage } from "./utils/pagination";
+import { getCustomBreadcrumbs } from "./helpers/breadcrumbs";
 
 export const getLinearScale = (domain, range, clamp = false) => {
   return (val) => {
@@ -146,10 +147,7 @@ export const useGlobalLanguage = () => {
 
 export const useCustomBreadcrumbs = (rootPageString) => {
   const rootPages = useGlobalData("rootPages");
-  const customBreadcrumbs = rootPages
-    .filter((p) => p.header?.includes(rootPageString))
-    .map((p) => p.pageEntry);
-  return customBreadcrumbs.flat(1);
+  return getCustomBreadcrumbs({ rootPages, header: rootPageString });
 };
 
 function dateWoTimezone(iso) {
@@ -201,38 +199,6 @@ export const makeCustomBreadcrumbs = (rootPages, rootPageString) => {
     .filter((p) => p.header.includes(rootPageString))
     .map((p) => p.pageEntry);
   return customBreadcrumbs.flat(1);
-};
-
-export const checkIfBetweenDates = (startDate, endDate) => {
-  if (!startDate || !endDate) {
-    return true;
-  }
-
-  const currentDate = new Date();
-  const from = new Date(startDate);
-  const to = new Date(endDate);
-
-  return currentDate > from && currentDate < to;
-};
-
-export const createLocationString = (
-  city,
-  state,
-  country,
-  address = "",
-  isFull = false
-) => {
-  // logic for displaying city/state in US, city/country outside
-  let start;
-  let end;
-  if (isFull) {
-    start = address ? address + ", " : "";
-    end = state ? state + ", " + country : country;
-  } else {
-    end = country === "USA" || country === "United States" ? state : country;
-  }
-  const loc = `${start || ""}${city ? city + ", " : ""}${end || ""}`;
-  return loc;
 };
 
 export function normalizeItemData(items, whichEntry = "entry") {

--- a/lib/utils/dates.ts
+++ b/lib/utils/dates.ts
@@ -1,0 +1,11 @@
+export const checkIfBetweenDates = (startDate: Date, endDate: Date) => {
+  if (!startDate || !endDate) {
+    return true;
+  }
+
+  const currentDate = new Date();
+  const from = new Date(startDate);
+  const to = new Date(endDate);
+
+  return currentDate > from && currentDate < to;
+};

--- a/services/craft/entries/content-blocks/skyviewer.ts
+++ b/services/craft/entries/content-blocks/skyviewer.ts
@@ -1,0 +1,31 @@
+import { graphql } from "@/gql";
+
+const SkyviewerBlockFragment = graphql(`
+  fragment skyviewerBlock on contentBlocks_skyviewer_BlockType {
+    id
+    embedTitle
+    typeHandle
+    captionRichText
+    dec
+    fov
+    ra
+    fullWidth
+    backgroundColor
+  }
+`);
+
+export const SkyviewerNewsBlockFragment = graphql(`
+  fragment skyviewerNewsBlock on contentBlocksNews_skyviewer_BlockType {
+    id
+    embedTitle
+    typeHandle
+    captionRichText
+    dec
+    fov
+    ra
+    fullWidth
+    backgroundColor
+  }
+`);
+
+export default SkyviewerBlockFragment;

--- a/services/craft/globals/rootPages.ts
+++ b/services/craft/globals/rootPages.ts
@@ -1,0 +1,49 @@
+"server-only";
+import { graphql, useFragment } from "@/gql";
+import queryAPI from "@/lib/api/client/query";
+import { getSiteFromLocale } from "@/lib/helpers/site";
+import { getLocale } from "@/lib/i18n/server";
+
+export const RootPagesFragment = graphql(`
+  fragment rootPageInfoFragment on rootPageInformation_GlobalSet {
+    name
+    handle
+    customBreadcrumbs {
+      ... on customBreadcrumbs_ancestorsAndRoot_BlockType {
+        header
+        pageEntry {
+          id
+          title
+          uri
+        }
+      }
+    }
+  }
+`);
+
+const getRootPages = async () => {
+  const site = getSiteFromLocale(getLocale());
+
+  const query = graphql(`
+    query getRootPages($site: [String], $set: [String]) {
+      rootPages: globalSet(handle: $set, site: $site) {
+        ...rootPageInfoFragment
+      }
+    }
+  `);
+
+  const { data } = await queryAPI({
+    query,
+    variables: { site, set: "rootPageInformation" },
+  });
+
+  if (!data || data.rootPages?.__typename !== "rootPageInformation_GlobalSet")
+    return undefined;
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const { customBreadcrumbs } = useFragment(RootPagesFragment, data.rootPages);
+
+  return customBreadcrumbs || undefined;
+};
+
+export default getRootPages;

--- a/theme/styles/abstracts/media.css
+++ b/theme/styles/abstracts/media.css
@@ -12,3 +12,5 @@
 @custom-media --phablet-max (width < 600px);
 @custom-media --mobile-max (width < 446px);
 @custom-media --mobile-small-max (width < 280px);
+@custom-media --portrait (orientation: portrait);
+@custom-media --landscape (orientation: landscape);


### PR DESCRIPTION
Resolves #690 

- adds a Skyviewer content block
  - no tests unfortunately since Cypress does not support server components in unit tests
  - move fragment to type-checked services folder
  - handles full width and embedded versions of the Skyviewer
- adds RichTextContent atom with tests
- extends server/client boundary to cover put `ContentBlockFactory` on the server on every page it is used so that server-only components like the Skyviewer can render

**Testing**

- Use in tandem with the [API branch](https://github.com/lsst-epo/rubin-obs-api/pull/355)
- add `SKYVIEWER_BASE_URL` to your `.env.local`
- On a new or existing page, add a Skyviewer content block (the homepage is fine)
- Configure with RA/DEC/FOV and other values (you can get these values by visiting the dev instance of the Skyviewer, and getting the URL from the share menu, it'll be in the URL params)
- Visit page
  - See that your content block is visible
  - See that Skyviewer functionality is present, particularly share features that can be blocked by iframe permissions
  - Make changes, check out the full width vs. embed, see that the changes are reflected
- Repeat by adding Skyviewer content block to a non-press release news article

**TODO**

Need to create a followup ticket to work with the content team on handling misconfigured Skyviewers, or Skyviewers that have an error when their iframe loads.