### PR TITLE
fix: use smaller Canto preview

### DIFF
--- a/components/organisms/gallery/CantoImage/index.tsx
+++ b/components/organisms/gallery/CantoImage/index.tsx
@@ -48,10 +48,11 @@ const CantoImage: FunctionComponent<CantoImageProps> = ({
         {...{ width, height }}
         data-cy="canto-image"
         alt={assetAlt(additional, locale)}
-        src={url.directUrlOriginal}
+        src={resizeCantoImage(url.directUrlPreview, 2050)}
         sizes={aspectRatio < 1 ? portraitSizes : landscapeSizes}
         quality={85}
         priority
+        fetchPriority="high"
         title={asset.name}
       />
     </>

--- a/lib/api/canto/resize.ts
+++ b/lib/api/canto/resize.ts
@@ -12,7 +12,7 @@ export const isValidCantoSize = (size: any): size is ValidCantoSize => {
   return ValidCantoSizes.includes(size);
 };
 
-export const resizeCantoImage = (previewUrl: string, size: number) => {
+export const resizeCantoImage = (previewUrl: string, size: ValidCantoSize) => {
   if (isValidCantoSize(size)) {
     const urlWithoutConstraint = previewUrl.slice(0, -3);
 


### PR DESCRIPTION
Resolves #761 

Uses the 2050px version of the Canto preview instead of the full resolution so ultra-large images do not gum up the Next image optimizer