### PR TITLE
fix: remove hardcoded color map from callouts

### DIFF
--- a/components/content-blocks/Callout/Wrapper.js
+++ b/components/content-blocks/Callout/Wrapper.js
@@ -13,7 +13,14 @@ export default function CalloutWrapper({
   isImage,
 }) {
   return (
-    <Section $bgColor={backgroundColor} $width={width} $overlay={overlay}>
+    <Section
+      style={{ "--color-background-section": `var(--${backgroundColor})` }}
+      data-dark-mode={
+        backgroundColor.includes("invert") || backgroundColor.includes("black")
+      }
+      $width={width}
+      $overlay={overlay}
+    >
       <Inner
         $isImage={isImage}
         $order={order}

--- a/components/content-blocks/Callout/styles.js
+++ b/components/content-blocks/Callout/styles.js
@@ -4,7 +4,6 @@ import {
   fluidScale,
   containerFullBleed,
   containerRegular,
-  needsDarkColor,
   pxToEm,
   respond,
   tokens,
@@ -16,14 +15,16 @@ const gap = "40px";
 const linkPadding = pxToEm("18px", "16px");
 
 export const Section = styled.section`
-  color: ${(p) =>
-    needsDarkColor(tokens[p.$bgColor]) ? tokens.neutral80 : tokens.white};
-  background-color: ${(p) => tokens[p.$bgColor]};
+  background-color: var(--color-background-section);
   ${(p) => p.$width === "block" && containerFullBleed("CONTAINER_REGULAR")};
   ${(p) =>
     p.$overlay &&
     `position: relative; top: -100px; background-color: transparent;
     ${respond(`top: -60px;`)}`};
+
+  &[data-dark-mode="true"] {
+    color: var(--color-font-invert);
+  }
 `;
 
 export const Inner = styled.div`


### PR DESCRIPTION
The callouts contain a re-implementation of the [Container](https://github.com/lsst-epo/epo-react-lib/blob/main/packages/epo-react-lib/src/molecules/Container/index.tsx) component in the `@rubin-epo/epo-react-lib`. The `Container` was updated months ago to interpret the `bgColor` prop as a CSS variable.

The reimplementation was not updated, and used a static map of background colors. When the background color returned undefined from the map, and was passed to the `needsDarkerColor` method, an exception was thrown. 

Updating to CSS variables removes this exception path, and if no matching CSS variable is found then the property is invalid and ignored.