### PR TITLE
fix: parse localized image links

### DIFF
--- a/helpers/noirlab.cy.ts
+++ b/helpers/noirlab.cy.ts
@@ -1,0 +1,88 @@
+import { Category } from "@/services/noirlab";
+import { isRubinAsset, rewriteAssetUrl } from "./noirlab";
+
+const imageId = "ann25007a";
+const imageUrl = `https://noirlab.edu/public/images/${imageId}/`;
+const videoId = "rubin-ComCamSkyVid1";
+const videoUrl = `https://noirlab.edu/public/videos/${videoId}/`;
+const localizedImageId = "ann25007b";
+const localizedImageUrl = `https://noirlab.edu/public/es/images/${localizedImageId}/`;
+
+describe("rewriteAssetUrl", () => {
+  it("should re-write a NOIRLab image gallery link to a Rubin image gallery link", () => {
+    const output = rewriteAssetUrl({ url: imageUrl, locale: "en" });
+
+    const { origin, pathname } = new URL(output);
+    const parts = pathname.split("/");
+    expect(origin).to.eq(Cypress.env("NEXT_PUBLIC_BASE_URL"));
+    expect(parts.pop()).to.eq(imageId);
+    expect(parts.pop()).to.eq("news-images");
+    expect(parts.pop()).to.eq("collections");
+    expect(parts.pop()).to.eq("gallery");
+  });
+  it("should re-write a NOIRLab video gallery link to a Rubin video gallery link", () => {
+    const output = rewriteAssetUrl({ url: videoUrl, locale: "en" });
+
+    const { origin, pathname } = new URL(output);
+    const parts = pathname.split("/");
+    expect(origin).to.eq(Cypress.env("NEXT_PUBLIC_BASE_URL"));
+    expect(parts.pop()).to.eq(videoId);
+    expect(parts.pop()).to.eq("news-videos");
+    expect(parts.pop()).to.eq("collections");
+    expect(parts.pop()).to.eq("gallery");
+  });
+  it("should re-write localized links", () => {
+    const locale = "es";
+    const output = rewriteAssetUrl({ url: localizedImageUrl, locale });
+
+    const { origin, pathname } = new URL(output);
+    const parts = pathname.split("/");
+    expect(origin).to.eq(Cypress.env("NEXT_PUBLIC_BASE_URL"));
+    expect(parts.pop()).to.eq(localizedImageId);
+    expect(parts.pop()).to.eq("news-images");
+    expect(parts.pop()).to.eq("collections");
+    expect(parts.pop()).to.eq("gallery");
+    expect(parts.pop()).to.eq(locale);
+  });
+  it("should re-write localized links that are not tagged correctly", () => {
+    const locale = "en";
+    const output = rewriteAssetUrl({
+      url: localizedImageUrl,
+      locale,
+    });
+
+    const { origin, pathname } = new URL(output);
+    const parts = pathname.split("/");
+    expect(origin).to.eq(Cypress.env("NEXT_PUBLIC_BASE_URL"));
+    expect(parts.pop()).to.eq(localizedImageId);
+    expect(parts.pop()).to.eq("news-images");
+    expect(parts.pop()).to.eq("collections");
+    expect(parts.pop()).to.eq("gallery");
+  });
+});
+
+const categories: Array<Category> = [
+  {
+    slug: "illustrations",
+    name: "Illustrations",
+    logo_url: null,
+  },
+  {
+    slug: "rubin",
+    name: "Vera C. Rubin Observatory",
+    logo_url: "https://noirlab.edu/public/static/images/logos/rubin.svg",
+  },
+];
+
+describe("isRubinAsset", () => {
+  it("should return `true` if the one of the tagged categories is Rubin", () => {
+    const result = isRubinAsset(categories);
+
+    expect(result).to.eq(true);
+  });
+  it("should return `false` if no categories match for Rubin", () => {
+    const result = isRubinAsset([categories[0]]);
+
+    expect(result).to.eq(false);
+  });
+});

--- a/lib/i18n/index.ts
+++ b/lib/i18n/index.ts
@@ -67,7 +67,7 @@ const shiftToSegments = (segments: Array<string>) => {
 };
 
 export const addLocaleUriSegment = (
-  locale: string,
+  locale = fallbackLng,
   uri: string,
   options: {
     includeLeadingSlash?: boolean;


### PR DESCRIPTION
Some image and video links coming from NOIRLab are prefixed with their locale (en or es). When I initially set up the URL re-writes, the links tested did not fall under this category and so I extracted from the URL starting from the beginning. With these locale prefixes set, values were off by 1 index.

Change to pull from the end of the URL instead since the only two values we need are at the end: asset ID and category.

Add tests around some of the low level helpers including the URL re-writer

Testing:
- Observe the initial issue here: https://rubinobservatory.org/news/host-first-look-watch-party
  - Spanish link is: https://rubinobservatory.org/gallery/collections/news-es/images when it should be https://rubinobservatory.org/gallery/collections/news-images/ann25007a
 - Check locally by pointing your `NEXT_PUBLIC_API_URL` to https://api-dev.rubinobs.com/api/, where the same post has been staged
   - The correct link should be shown as [localhost]/es/gallery/collections/news-images/ann25007b

A future ticket will address filtering images to the current locale, depending on if we can get NOIRLab to do this on the API side or not.