### PR TITLE
fix: clear client cache after changing locale

### DIFF
--- a/components/organisms/Header/LanguageSelect/index.js
+++ b/components/organisms/Header/LanguageSelect/index.js
@@ -33,6 +33,7 @@ export default function LanguageSelect({ className }) {
 
   useEffect(() => {
     setLoading(false);
+    router.refresh();
   }, [pathname]);
 
   const handleClick = () => {

--- a/cypress/e2e/header.cy.js
+++ b/cypress/e2e/header.cy.js
@@ -17,13 +17,7 @@ describe("Header", () => {
     cy.get("[data-cy=header] nav > ul").should("exist");
     cy.get("[data-cy=header] nav > ul").children().should("have.length.gt", 0);
   });
-  it("has a toggle for language", () => {
-    cy.get("[data-cy=localeToggle]").should("exist");
-    cy.get("[data-cy=localeToggle] button").filter(":visible").click();
-    cy.on("url:changed", (newUrl) => {
-      expect(newUrl).to.contain("es");
-    });
-  });
+
   it("yields results when searching", () => {
     cy.get("[data-cy=searchBar] button[aria-expanded=false]")
       .filter(":visible")

--- a/cypress/e2e/i18n.cy.ts
+++ b/cypress/e2e/i18n.cy.ts
@@ -1,0 +1,28 @@
+import { fallbackLng } from "@/lib/i18n/settings";
+
+describe("Localized routing", () => {
+  it("should localize the browser", () => {
+    cy.visit("/").then((window) => {
+      cy.getAllCookies();
+      cy.get("html").should("have.attr", "lang", fallbackLng);
+    });
+  });
+  it("has a toggle for language", () => {
+    cy.visit("/").then(() => {
+      cy.get("[data-cy=localeToggle]").should("exist");
+      cy.get("[data-cy=localeToggle] button").filter(":visible").click();
+      cy.on("url:changed", () => {
+        cy.get("html").should("have.attr", "lang", "es");
+      });
+    });
+  });
+  it("stays in the language selected", () => {
+    cy.visit("/").then(() => {
+      cy.get("[data-cy=localeToggle] button").filter(":visible").click();
+
+      cy.visit("/about").then(() => {
+        cy.get("html").should("have.attr", "lang", "es");
+      });
+    });
+  });
+});

--- a/env.ts
+++ b/env.ts
@@ -4,7 +4,10 @@ import { z } from "zod";
 export const env = createEnv({
   emptyStringAsUndefined: true,
   shared: {
-    NODE_ENV: z.enum(["development", "test", "production"]).default("test"),
+    NODE_ENV: z
+      .enum(["development", "test", "production"])
+      .catch("test")
+      .default("test"),
   },
   server: {
     BING_INDEXNOW_KEY: z.string().min(1).optional(),

--- a/lib/i18n/client.js
+++ b/lib/i18n/client.js
@@ -5,11 +5,11 @@ import LanguageDetector from "i18next-browser-languagedetector";
 import {
   defaultNS,
   languages,
-  getOptions,
   namespaces,
   cookieName,
   fallbackLng,
 } from "./settings";
+import { getOptions } from "./options";
 import { loadResources } from "./index";
 
 const runsOnServerSide = typeof window === "undefined";

--- a/lib/i18n/index.ts
+++ b/lib/i18n/index.ts
@@ -1,7 +1,8 @@
 import { createInstance } from "i18next";
 import resourcesToBackend from "i18next-resources-to-backend";
 import { initReactI18next } from "react-i18next/initReactI18next";
-import { fallbackLng, getOptions } from "./settings";
+import { fallbackLng } from "./settings";
+import { getOptions } from "./options";
 
 export const loadResources = resourcesToBackend(
   (language: string, namespace: string, callback) => {

--- a/lib/i18n/options.ts
+++ b/lib/i18n/options.ts
@@ -1,0 +1,25 @@
+import { type InitOptions } from "i18next";
+import { defaultNS, fallbackLng, languages } from "./settings";
+import { env } from "@/env";
+
+export function getOptions(lng = fallbackLng, ns = defaultNS): InitOptions {
+  return {
+    debug: env.NODE_ENV === "development" && typeof window !== "undefined",
+    supportedLngs: languages,
+    fallbackLng,
+    lng,
+    fallbackNS: defaultNS,
+    defaultNS,
+    ns,
+    load: "languageOnly",
+    react: {
+      transSupportBasicHtmlNodes: true,
+    },
+    interpolation: {
+      escapeValue: false,
+    },
+    backend: {
+      loadPath: `${env.NEXT_PUBLIC_BASE_URL}/localeStrings/{{lng}}/{{ns}}.json`,
+    },
+  };
+}

--- a/lib/i18n/settings.ts
+++ b/lib/i18n/settings.ts
@@ -1,31 +1,6 @@
-import { type InitOptions } from "i18next";
-import { env } from "@/env";
-
 export const fallbackLng = "en";
 export const languages = [fallbackLng, "es"] as const;
 export const defaultNS = "translation";
 export const namespaces = [defaultNS];
 export const cookieName = "NEXT_LOCALE";
 export type Locale = (typeof languages)[number];
-
-export function getOptions(lng = fallbackLng, ns = defaultNS): InitOptions {
-  return {
-    debug: env.NODE_ENV === "development" && typeof window !== "undefined",
-    supportedLngs: languages,
-    fallbackLng,
-    lng,
-    fallbackNS: defaultNS,
-    defaultNS,
-    ns,
-    load: "languageOnly",
-    react: {
-      transSupportBasicHtmlNodes: true,
-    },
-    interpolation: {
-      escapeValue: false,
-    },
-    backend: {
-      loadPath: `${env.NEXT_PUBLIC_BASE_URL}/localeStrings/{{lng}}/{{ns}}.json`,
-    },
-  };
-}


### PR DESCRIPTION
Resolves #829 

The client router needs to be refreshed after locale changes, or else after switching from Spanish -> English, next will still include the pathname prefixed with `es` which triggers the i18n to perform a manual switch to Spanish and reset the cookie.