### PR TITLE
feat: web share for image files

### DIFF
--- a/app/[locale]/gallery/collections/[gallery]/[asset]/page.tsx
+++ b/app/[locale]/gallery/collections/[gallery]/[asset]/page.tsx
@@ -141,7 +141,19 @@ const GalleryAsset: FunctionComponent<GalleryAssetProps> = async ({
       actions={
         <>
           <CantoDownload directUrlOriginal={directUrlOriginal} />
-          <SharePopup title={name} url={`gallery/${gallery}/${id}`} />
+          <SharePopup
+            title={name}
+            url={`gallery/${gallery}/${id}`}
+            file={
+              scheme === "image"
+                ? {
+                    url: directUrlPreview,
+                    name: asset.name,
+                    type: asset.default.ContentType,
+                  }
+                : undefined
+            }
+          />
         </>
       }
       metadataBlocks={

--- a/components/molecules/SharePopup/index.tsx
+++ b/components/molecules/SharePopup/index.tsx
@@ -9,8 +9,8 @@ import Button from "@rubin-epo/epo-react-lib/Button";
 import { env } from "@/env";
 import { isAbsoluteUrl } from "@/helpers";
 import ShareButtons from "@/components/molecules/Share";
-import styles from "./styles.module.css";
 import { shouldShare } from "@/lib/utils/share";
+import styles from "./styles.module.css";
 
 const BASE_URL = env.NEXT_PUBLIC_BASE_URL;
 
@@ -26,6 +26,7 @@ interface SharePopupProps {
   variant?: "primary" | "block";
   title?: string;
   url?: string;
+  file?: { url: string; name: string; type: string };
   className?: string;
 }
 
@@ -33,6 +34,7 @@ const SharePopup: FC<SharePopupProps> = ({
   variant,
   title,
   url,
+  file,
   className,
 }) => {
   const pathname = usePathname();
@@ -56,13 +58,23 @@ const SharePopup: FC<SharePopupProps> = ({
     if (shouldShare()) {
       event.preventDefault();
 
-      const data: ShareData = { title, url: finalUrl };
+      const files: Array<File> = [];
 
-      try {
-        navigator.share(data);
-      } catch (error) {
-        console.warn(error);
+      if (file) {
+        const { url, type, name } = file;
+        const response = await fetch(url, { cache: "force-cache" });
+
+        if (response.ok) {
+          const blob = await response.blob();
+          files.push(new File([blob], name, { type }));
+        }
       }
+
+      const data: ShareData = { title, url: finalUrl, files };
+
+      navigator.share(data).catch((error) => {
+        console.warn(error);
+      });
     }
   };
 


### PR DESCRIPTION
Resolves #777 

Adds image files on the gallery pages to the web share setup. Does not apply to:

- Video pages, because downloading a video to put into the share files would take too long
- NOIRLab pages, because the share API rejects files from a cross origin domain