### PR TITLE
refactor: statically render canto gallery pages

### DIFF
--- a/app/[locale]/gallery/collections/[gallery]/[asset]/layout.tsx
+++ b/app/[locale]/gallery/collections/[gallery]/[asset]/layout.tsx
@@ -1,18 +1,37 @@
 import { FunctionComponent, PropsWithChildren } from "react";
+import { Metadata } from "next";
+import { notFound } from "next/navigation";
 import Container from "@rubin-epo/epo-react-lib/Container";
 import Stack from "@rubin-epo/epo-react-lib/Stack";
-import { getAssetBreadcrumb, getRecentAssets } from "@/lib/api/galleries/asset";
+import {
+  getAssetBreadcrumb,
+  getAssetFromGallery,
+  getFirstPageAssets,
+} from "@/lib/api/galleries/asset";
 import { useTranslation } from "@/lib/i18n";
 import { isMainGallery } from "@/lib/api/galleries";
 import { buildParentPath } from "@/lib/helpers/gallery";
 import Breadcrumbs from "@/components/page/Breadcrumbs";
 import BackButton from "@/components/molecules/BackButton";
 import MediaPolicy from "@/components/organisms/gallery/MediaPolicy";
+import { assetToPageMetadata } from "@/lib/api/canto/metadata";
 
 export async function generateStaticParams({
   params: { locale, gallery },
 }: GalleryProps) {
-  return getRecentAssets(locale, gallery);
+  return getFirstPageAssets(locale, gallery);
+}
+
+export async function generateMetadata({
+  params: { locale, gallery, asset: id },
+}: GalleryAssetProps): Promise<Metadata> {
+  const asset = await getAssetFromGallery(gallery, id, locale);
+
+  if (!asset) {
+    notFound();
+  }
+
+  return assetToPageMetadata(asset, locale);
 }
 
 const AssetLayout: FunctionComponent<

--- a/app/[locale]/gallery/collections/[gallery]/[asset]/page.tsx
+++ b/app/[locale]/gallery/collections/[gallery]/[asset]/page.tsx
@@ -1,13 +1,8 @@
 import { ComponentType, FunctionComponent } from "react";
-import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { env } from "@/env";
 import { getAssetFromGallery } from "@/lib/api/galleries/asset";
-import {
-  assetCaption,
-  assetTitle,
-  assetToPageMetadata,
-} from "@/lib/api/canto/metadata";
+import { assetCaption, assetTitle } from "@/lib/api/canto/metadata";
 import { SupportedCantoAssetScheme } from "@/lib/api/galleries/schema";
 import { isMainGallery } from "@/lib/api/galleries";
 import { getMediaPolicyPage } from "@/lib/api/galleries/media-policy";
@@ -25,18 +20,7 @@ import LinkedPosts from "@/components/organisms/gallery/metadata/LinkedPosts";
 import CantoDownload from "@/components/organisms/gallery/CantoDownload";
 import BackToGallery from "@/components/organisms/gallery/BackToGallery";
 import DocumentInfo from "@/components/molecules/DocumentInfo";
-
-export async function generateMetadata({
-  params: { locale, gallery, asset: id },
-}: GalleryAssetProps): Promise<Metadata> {
-  const asset = await getAssetFromGallery(gallery, id, locale);
-
-  if (!asset) {
-    notFound();
-  }
-
-  return assetToPageMetadata(asset, locale);
-}
+import { setRequestLocale } from "next-intl/server";
 
 const assetComponent: Record<SupportedCantoAssetScheme, ComponentType<any>> = {
   image: CantoImage,
@@ -47,6 +31,7 @@ const assetComponent: Record<SupportedCantoAssetScheme, ComponentType<any>> = {
 const GalleryAsset: FunctionComponent<GalleryAssetProps> = async ({
   params: { locale, gallery, asset: id },
 }) => {
+  setRequestLocale(locale);
   const { t } = await useTranslation(locale);
   const asset = await getAssetFromGallery(gallery, id, locale);
 

--- a/app/[locale]/gallery/collections/[gallery]/layout.tsx
+++ b/app/[locale]/gallery/collections/[gallery]/layout.tsx
@@ -1,15 +1,13 @@
 import { FunctionComponent, PropsWithChildren } from "react";
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { getAllGalleries, getGalleryMetadata } from "@/lib/api/galleries";
+import { getAllGallerySlugs, getGalleryMetadata } from "@/lib/api/galleries";
 import { assetToOpenGraphImage } from "@/lib/api/canto/metadata";
-
-export const dynamicParams = false;
 
 export async function generateStaticParams({
   params: { locale },
 }: LocaleProps) {
-  return getAllGalleries(locale);
+  return getAllGallerySlugs(locale);
 }
 
 export async function generateMetadata({
@@ -39,7 +37,5 @@ export const GalleryLayout: FunctionComponent<PropsWithChildren> = ({
 }) => {
   return <>{children}</>;
 };
-
-export const dynamic = "force-dynamic";
 
 export default GalleryLayout;

--- a/app/[locale]/gallery/collections/[gallery]/page.tsx
+++ b/app/[locale]/gallery/collections/[gallery]/page.tsx
@@ -20,6 +20,4 @@ const Gallery: FunctionComponent<WithSearchParams<GalleryProps>> = async ({
   return <GalleryPage {...{ locale, gallery, searchParams }} />;
 };
 
-export const dynamic = "force-dynamic";
-
 export default Gallery;


### PR DESCRIPTION
Resolves #853

Turns on static generation for Canto gallery pages, will generate the first page of gallery assets for each gallery during build