### PR TITLE
fix: remove 'error' route segment config

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -18,6 +18,4 @@ const RootPage: FunctionComponent<LocaleProps> = async ({
   return <HomePageTemplate data={data} locale={locale} />;
 };
 
-export const dynamic = "error";
-
 export default RootPage;


### PR DESCRIPTION
Remove `error` from the route segment dynamic config so it does not block draft mode dynamic rendering.