### PR TITLE
feat: revalidation from preview mode

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -98,9 +98,8 @@ const LocaleLayout: FunctionComponent<PropsWithChildren<LocaleProps>> = async ({
                   <SkeletonGlobal>
                     <GoogleOAuthProvider clientId={GOOGLE_APP_ID}>
                       <GlobalStyles />
-                      <PreviewMode>
-                        <PageWrapper {...{ locale }}>{children}</PageWrapper>
-                      </PreviewMode>
+                      <PreviewMode />
+                      <PageWrapper {...{ locale }}>{children}</PageWrapper>
                     </GoogleOAuthProvider>
                   </SkeletonGlobal>
                 </StyledComponentsRegistry>

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,14 +1,8 @@
-import { revalidatePath } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
 import { env } from "@/env";
-import indexNow from "@/services/revalidation/indexNow";
-import additionalRevalidations from "@/services/revalidation/additional";
-import { languages } from "@/lib/i18n/settings";
-import { addLocaleUriSegment } from "@/lib/i18n";
+import revalidate from "@/services/revalidation";
 
 const REVALIDATE_SECRET_TOKEN = env.CRAFT_REVALIDATE_SECRET_TOKEN;
-const CRAFT_HOMEPAGE_URI = "__home__";
-const ENV = env.CLOUD_ENV;
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
   const uri = request.nextUrl.searchParams.get("uri");
@@ -31,21 +25,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   }
 
   if (uri) {
-    languages.forEach((locale) => {
-      const parts: Array<string> =
-        uri === CRAFT_HOMEPAGE_URI ? [] : uri.split("/");
-
-      const path = addLocaleUriSegment(locale, parts.join("/"), {
-        includeLeadingSlash: false,
-      });
-
-      revalidatePath(`/${path}`);
-      additionalRevalidations(parts);
-    });
-
-    if (ENV === "PROD") {
-      await indexNow(uri);
-    }
+    revalidate(uri);
 
     return NextResponse.json({ revalidated: true, now: Date.now() });
   }

--- a/components/organisms/PreviewMode/Banner/index.tsx
+++ b/components/organisms/PreviewMode/Banner/index.tsx
@@ -1,27 +1,18 @@
 "use client";
-import { FC, useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import { FC, PropsWithChildren, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import IconComposer from "@rubin-epo/epo-react-lib/IconComposer";
-import endPreviewMode from "@/services/actions/endPreviewMode";
 import styles from "./styles.module.css";
 
-const Banner: FC = () => {
+const Banner: FC<PropsWithChildren> = ({ children }) => {
   const { t } = useTranslation();
   const [isLivePreview, setLivePreview] = useState(false);
-  const { refresh } = useRouter();
 
   useEffect(() => {
     if (window && window.top !== window.self) {
       setLivePreview(true);
     }
   }, []);
-
-  const handleDisable = async () => {
-    await endPreviewMode();
-
-    refresh();
-  };
 
   if (isLivePreview) return null;
 
@@ -31,9 +22,7 @@ const Banner: FC = () => {
         <IconComposer icon="InfoCircle" />
         {t("preview_mode.is_enabled")}
       </span>
-      <button className={styles.disableButton} onClick={handleDisable}>
-        {t("preview_mode.disable")}
-      </button>
+      <div className={styles.actions}>{children}</div>
     </div>
   );
 };

--- a/components/organisms/PreviewMode/Banner/styles.module.css
+++ b/components/organisms/PreviewMode/Banner/styles.module.css
@@ -16,13 +16,14 @@
   display: flex;
   align-items: center;
   gap: 1ex;
+  flex-shrink: 0;
+  white-space: nowrap;
 }
 
-.disableButton {
+.actions {
   display: flex;
   align-items: center;
-  padding: var(--size-spacing-3xs) var(--size-spacing-2xs);
-  border: 2px solid currentcolor;
-  border-radius: var(--size-spacing-2xs);
-  height: var(--size-spacing-s);
+  justify-content: flex-end;
+  flex-grow: 1;
+  gap: var(--size-spacing-3xs);
 }

--- a/components/organisms/PreviewMode/Disable/index.tsx
+++ b/components/organisms/PreviewMode/Disable/index.tsx
@@ -1,0 +1,31 @@
+"use client";
+import { FC, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { useTranslation } from "react-i18next";
+import endPreviewMode from "@/services/actions/endPreviewMode";
+import styles from "../styles.module.css";
+
+const DisablePreviewMode: FC = () => {
+  const [isPending, startTransition] = useTransition();
+  const { t } = useTranslation();
+  const { refresh } = useRouter();
+  const handleDisable = async () => {
+    await endPreviewMode();
+
+    refresh();
+  };
+
+  return (
+    <button
+      className={styles.button}
+      onClick={() => startTransition(handleDisable)}
+      disabled={isPending}
+    >
+      {t("preview_mode.exit")}
+    </button>
+  );
+};
+
+DisablePreviewMode.displayName = "Organism.PreviewMode.Disable";
+
+export default DisablePreviewMode;

--- a/components/organisms/PreviewMode/Revalidate/index.tsx
+++ b/components/organisms/PreviewMode/Revalidate/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { FC, useEffect, useId, useState, useTransition } from "react";
-import { usePathname } from "@/lib/i18n/navigation";
+import { usePathname, useRouter } from "@/lib/i18n/navigation";
 import { useTranslation } from "react-i18next";
 import { Transition } from "@headlessui/react";
 import styles from "./styles.module.css";
@@ -16,6 +16,7 @@ const RevalidateCurrentPath: FC<{ token: string }> = ({ token }) => {
   const { t } = useTranslation();
   const [isPending, startTransition] = useTransition();
   const pathname = usePathname();
+  const router = useRouter();
 
   useEffect(() => {
     setRevalidationState(undefined);
@@ -25,6 +26,14 @@ const RevalidateCurrentPath: FC<{ token: string }> = ({ token }) => {
     const revalidated = await revalidate({ uri: pathname, token });
 
     if (revalidated) {
+      console.info({ revalidated });
+      router.replace(
+        {
+          pathname,
+          query: { "": new Date().getMilliseconds().toString() },
+        },
+        { scroll: false }
+      );
       setRevalidationState({
         state: "success",
         message: t("preview_mode.revalidate", {

--- a/components/organisms/PreviewMode/Revalidate/index.tsx
+++ b/components/organisms/PreviewMode/Revalidate/index.tsx
@@ -1,0 +1,87 @@
+"use client";
+import { FC, useEffect, useId, useState, useTransition } from "react";
+import { usePathname } from "@/lib/i18n/navigation";
+import { useTranslation } from "react-i18next";
+import { useRouter } from "next/navigation";
+import { Transition } from "@headlessui/react";
+import styles from "./styles.module.css";
+
+const RevalidateCurrentPath: FC<{ token: string }> = ({ token }) => {
+  const id = useId();
+  const [showTooltip, setShowTooltip] = useState(false);
+  const [revalidationState, setRevalidationState] = useState<{
+    state: "success" | "error";
+    message: string;
+  }>();
+  const { t } = useTranslation();
+  const [isPending, startTransition] = useTransition();
+  const { refresh } = useRouter();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    setRevalidationState(undefined);
+  }, [pathname]);
+
+  const handleRevalidate = async () => {
+    const params = new URLSearchParams({ uri: pathname, secret: token });
+
+    const response = await fetch(`api/revalidate?${params.toString()}`, {
+      cache: "no-store",
+    });
+
+    if (response.ok) {
+      refresh();
+      setRevalidationState({
+        state: "success",
+        message: t("preview_mode.revalidate", {
+          context: "success",
+          pathname,
+        }),
+      });
+    } else {
+      setRevalidationState({
+        state: "error",
+        message:
+          response.statusText ||
+          t("preview_mode.revalidate", { context: "error" }),
+      });
+    }
+  };
+
+  return (
+    <div className={styles.revalidation}>
+      <output htmlFor={id} className={styles.output}>
+        <Transition show={!isPending && !!revalidationState}>
+          <span className={styles.outputText}>
+            {revalidationState?.message}
+          </span>
+        </Transition>
+      </output>
+      <div className={styles.buttonWrapper}>
+        <button
+          id={id}
+          aria-describedby={`${id}-description`}
+          className={styles.button}
+          onClick={() => {
+            setRevalidationState(undefined);
+            startTransition(handleRevalidate);
+          }}
+          onMouseEnter={() => setShowTooltip(true)}
+          onMouseLeave={() => setShowTooltip(false)}
+          disabled={isPending}
+        >
+          {t("preview_mode.revalidate")}
+        </button>
+        <Transition unmount={false} show={showTooltip}>
+          <div id={`${id}-description`} className={styles.panel}>
+            {t("preview_mode.revalidate_tooltip")}
+          </div>
+        </Transition>
+      </div>
+    </div>
+  );
+};
+
+RevalidateCurrentPath.displayName = "Organism.PreviewMode.Revalidate";
+
+export default RevalidateCurrentPath;

--- a/components/organisms/PreviewMode/Revalidate/styles.module.css
+++ b/components/organisms/PreviewMode/Revalidate/styles.module.css
@@ -1,0 +1,59 @@
+.revalidation {
+  --size-gap-container: var(--size-spacing-3xs);
+  display: flex;
+  align-items: stretch;
+  justify-content: flex-end;
+  flex-grow: 1;
+  height: var(--size-spacing-s);
+  gap: var(--size-gap-container);
+}
+
+.buttonWrapper {
+  position: relative;
+}
+
+.button {
+  composes: button from "../styles.module.css";
+}
+
+.panel {
+  background-color: var(--color-background-page-invert);
+  color: var(--color-font-invert);
+  padding: var(--size-spacing-3xs);
+  font-size: 80%;
+  text-wrap: pretty;
+  width: 50ch;
+  position: absolute;
+  top: calc(var(--size-spacing-2xs) * -1);
+  transform: translate(50%, -100%);
+  transition: 0.2s opacity ease-in-out;
+  opacity: 1;
+  right: 50%;
+
+  &[data-closed] {
+    opacity: 0;
+  }
+}
+
+.output {
+  display: flex;
+  align-items: center;
+  flex-grow: 1;
+  white-space: nowrap;
+  text-align: end;
+  position: relative;
+  overflow: hidden;
+}
+
+.outputText {
+  position: absolute;
+  right: 0;
+  transition: transform 0.2s ease-in-out, opacity 0.15s 0.05s ease-in-out;
+  transform: translateX(0);
+  opacity: 1;
+
+  &[data-closed] {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+}

--- a/components/organisms/PreviewMode/index.tsx
+++ b/components/organisms/PreviewMode/index.tsx
@@ -1,15 +1,20 @@
 import { draftMode } from "next/headers";
-import { FC, PropsWithChildren } from "react";
+import { FC } from "react";
+import { env } from "@/env";
 import Banner from "./Banner";
+import DisablePreviewMode from "./Disable";
+import RevalidateCurrentPath from "./Revalidate";
 
-const PreviewMode: FC<PropsWithChildren> = ({ children }) => {
+const PreviewMode: FC = () => {
   const { isEnabled } = draftMode();
 
+  if (!isEnabled) return null;
+
   return (
-    <>
-      {isEnabled && <Banner />}
-      {children}
-    </>
+    <Banner>
+      <RevalidateCurrentPath token={env.CRAFT_REVALIDATE_SECRET_TOKEN} />
+      <DisablePreviewMode />
+    </Banner>
   );
 };
 

--- a/components/organisms/PreviewMode/styles.module.css
+++ b/components/organisms/PreviewMode/styles.module.css
@@ -1,0 +1,14 @@
+.button {
+  display: flex;
+  align-items: center;
+  padding: var(--size-spacing-3xs) var(--size-spacing-2xs);
+  border: 2px solid currentcolor;
+  border-radius: var(--size-spacing-2xs);
+  height: var(--size-spacing-s);
+  white-space: nowrap;
+
+  &:disabled {
+    opacity: 0.67;
+    cursor: wait;
+  }
+}

--- a/lib/i18n/localeStrings/en/translation.json
+++ b/lib/i18n/localeStrings/en/translation.json
@@ -470,7 +470,11 @@
   },
   "preview_mode": {
     "is_enabled": "Preview mode is enabled",
-    "disable": "Disable"
+    "revalidate": "Revalidate",
+    "revalidate_success": "{{pathname}} was revalidated",
+    "revalidate_error": "There was a problem revalidating this page",
+    "revalidate_tooltip": "If your page uses an external resource like NOIRLab's news and image feed, requesting revalidation may update content on the page.",
+    "exit": "Exit preview mode"
   },
   "scroll_carousel": {
     "label": "Go to slide {{value}}"

--- a/services/actions/revalidate.ts
+++ b/services/actions/revalidate.ts
@@ -2,6 +2,7 @@
 
 import { env } from "@/env";
 import revalidateUri from "@/services/revalidation";
+import { redirect, RedirectType } from "next/navigation";
 
 export default async function revalidate({
   uri,
@@ -11,6 +12,18 @@ export default async function revalidate({
   token: string;
 }) {
   if (uri && token === env.CRAFT_REVALIDATE_SECRET_TOKEN) {
-    return revalidateUri(uri);
+    const revalidation = revalidateUri(uri);
+
+    const params = new URLSearchParams({
+      now: new Date().getTime().toString(),
+    });
+
+    Object.entries(revalidation).forEach(([key, revalidated]) => {
+      revalidated.forEach((value) => {
+        params.append(key, value);
+      });
+    });
+
+    redirect(`?${params.toString()}`, RedirectType.replace);
   }
 }

--- a/services/actions/revalidate.ts
+++ b/services/actions/revalidate.ts
@@ -1,0 +1,16 @@
+"use server";
+
+import { env } from "@/env";
+import revalidateUri from "@/services/revalidation";
+
+export default async function revalidate({
+  uri,
+  token,
+}: {
+  uri: string;
+  token: string;
+}) {
+  if (uri && token === env.CRAFT_REVALIDATE_SECRET_TOKEN) {
+    return revalidateUri(uri);
+  }
+}

--- a/services/revalidation/additional.ts
+++ b/services/revalidation/additional.ts
@@ -8,7 +8,7 @@ type Revalidator = (props: {
 }) => void;
 
 const revalidateGalleries: Revalidator = ({ parts, tagCollection }) => {
-  const [, , slug] = parts;
+  const slug = parts.pop();
 
   if (slug) {
     tagCollection.add(slug);
@@ -21,19 +21,22 @@ const revalidators: Record<string, Revalidator> = {
 };
 
 const additionalRevalidations: Revalidator = ({ parts, tagCollection }) => {
-  const section = parts[0];
-  const revalidator = revalidators[section];
+  const section = parts.find((part) => part.length > 0);
 
-  if (tags[section]) {
+  if (section) {
+    const revalidator = revalidators[section];
     const tag = tags[section];
-    tagCollection.add(tag);
-    revalidateTag(tag);
+
+    if (tag) {
+      tagCollection.add(tag);
+      revalidateTag(tag);
+    }
+
+    revalidator && revalidator({ parts, tagCollection });
+
+    tagCollection.add(tags.globals);
+    revalidateTag(tags.globals);
   }
-
-  revalidator && revalidator({ parts, tagCollection });
-
-  tagCollection.add(tags.globals);
-  revalidateTag(tags.globals);
 };
 
 export default additionalRevalidations;

--- a/services/revalidation/index.ts
+++ b/services/revalidation/index.ts
@@ -1,0 +1,35 @@
+"server-only";
+import { revalidatePath } from "next/cache";
+import { env } from "@/env";
+import indexNow from "@/services/revalidation/indexNow";
+import additionalRevalidations from "@/services/revalidation/additional";
+import { languages } from "@/lib/i18n/settings";
+import { getPathname } from "@/lib/i18n/navigation";
+
+const CRAFT_HOMEPAGE_URI = "__home__";
+const ENV = env.CLOUD_ENV;
+
+const revalidate = (uri: string) => {
+  const paths: Array<string> = [];
+  const tagCollection = new Set<string>();
+
+  languages.forEach((locale) => {
+    const parts: Array<string> =
+      uri === CRAFT_HOMEPAGE_URI ? [] : uri.split("/");
+
+    const path = getPathname({ href: parts.join("/"), locale });
+
+    paths.push(path);
+
+    revalidatePath(path);
+    additionalRevalidations({ parts, tagCollection });
+  });
+
+  if (ENV === "PROD") {
+    indexNow(uri);
+  }
+
+  return { paths, tags: Array.from(tagCollection) };
+};
+
+export default revalidate;


### PR DESCRIPTION
Resolves #862 

Adds revalidation requests to the preview pane, with tooltip explaining the purpose of the feature.

To test:
- Open up a page in preview mode
- Back in Craft, make a change _but do not save_, since we're in preview mode we can get the draft data from Craft without saving
- In the preview page, click "Revalidate", and receive a success message
- See the page update with your change

![image](https://github.com/user-attachments/assets/d83aef15-2432-41f4-ac4a-7b6d4d4aeae3)
