### PR TITLE
refactor: static render uriSegments

### DIFF
--- a/app/[locale]/[...uriSegments]/layout.tsx
+++ b/app/[locale]/[...uriSegments]/layout.tsx
@@ -120,6 +120,4 @@ const UriSegmentsLayout: FC<PropsWithChildren<UriSegmentProps>> = ({
   return <>{children}</>;
 };
 
-export const dynamic = "force-dynamic";
-
 export default UriSegmentsLayout;

--- a/app/[locale]/[...uriSegments]/page.tsx
+++ b/app/[locale]/[...uriSegments]/page.tsx
@@ -1,5 +1,6 @@
 import { FunctionComponent } from "react";
 import { notFound, redirect, RedirectType } from "next/navigation";
+import { setRequestLocale } from "next-intl/server";
 import { getBreadcrumbsById } from "@/lib/api/metadata";
 import { getEntrySectionByUri } from "@/lib/api/entries/index";
 import { getEntryDataByUri } from "@/lib/api/entry";
@@ -26,6 +27,7 @@ const pageMap = {
 const UriSegmentsPage: FunctionComponent<
   WithSearchParams<UriSegmentProps>
 > = async ({ params: { locale, uriSegments }, searchParams = {} }) => {
+  setRequestLocale(locale);
   const uri = uriSegments.join("/");
 
   const entrySectionType = await getEntrySectionByUri(uri, locale);
@@ -56,7 +58,5 @@ const UriSegmentsPage: FunctionComponent<
 
   return <Template {...{ section, breadcrumbs, data, locale, searchParams }} />;
 };
-
-export const dynamic = "force-dynamic";
 
 export default UriSegmentsPage;


### PR DESCRIPTION
Resolves #854 

Removes forced dynamic render from `uriSegments`, will add about ~400 new static page generations to the full production build, and a few dozen to dev server builds.

Some pages like the gallery landing pages will be skipped because they use `searchParams` to dynamically generate page results for with searching/filtering/pagination.

Should wait to merge until persistent data cache is available, so that build times are not greatly increased.