### PR TITLE
fix: disable prefetch on navigation menu

### DIFF
--- a/components/molecules/Pagination/index.tsx
+++ b/components/molecules/Pagination/index.tsx
@@ -1,9 +1,9 @@
 "use client";
 import React, { FC } from "react";
 import Link from "next/link";
-import { Trans, useTranslation } from "react-i18next";
-import styles from "./styles.module.scss";
 import { useSearchParams } from "next/navigation";
+import { Trans, useTranslation } from "react-i18next";
+import styles from "./styles.module.css";
 
 interface PaginationProps {
   limit: number;
@@ -67,6 +67,7 @@ const Pagination: FC<PaginationProps> = ({
                   <Link
                     aria-current={page === currentPage ? "page" : false}
                     href={{ query: { ...query, page } }}
+                    prefetch={false}
                   >
                     {page}
                   </Link>
@@ -79,7 +80,11 @@ const Pagination: FC<PaginationProps> = ({
         </div>
         <div>
           {prev > 0 ? (
-            <Link rel="prev" href={{ query: { ...query, page: prev } }}>
+            <Link
+              rel="prev"
+              href={{ query: { ...query, page: prev } }}
+              prefetch={false}
+            >
               {t("pagination.previous")}
             </Link>
           ) : (
@@ -98,7 +103,11 @@ const Pagination: FC<PaginationProps> = ({
       <nav className={styles.navMobile} aria-label={t("pagination.label")}>
         <div>
           {prev > 0 ? (
-            <Link rel="prev" href={{ query: { ...query, page: prev } }}>
+            <Link
+              rel="prev"
+              href={{ query: { ...query, page: prev } }}
+              prefetch={false}
+            >
               &lt;&lt;
             </Link>
           ) : (

--- a/components/molecules/Pagination/styles.module.css
+++ b/components/molecules/Pagination/styles.module.css
@@ -19,7 +19,7 @@
   grid-template-columns: repeat(3, 1fr);
   gap: var(--size-spacing-s);
 
-  @include base.respond(functions.break(tablet)) {
+  @media (--tablet-max) {
     display: none;
   }
 
@@ -41,8 +41,7 @@
   & > div:last-child {
     justify-self: end;
   }
-
-  @include base.respond(functions.break(tablet) + 1, min) {
+  @media (--tablet) {
     display: none;
   }
 }

--- a/components/molecules/TagList/index.tsx
+++ b/components/molecules/TagList/index.tsx
@@ -30,7 +30,13 @@ const TagList: FunctionComponent<TagListProps> = ({
 
         return (
           <li className={styles.tag} data-no-break={!withLinebreaks} key={name}>
-            {destination ? <Link href={destination}>{tagName}</Link> : tagName}
+            {destination ? (
+              <Link href={destination} prefetch={false}>
+                {tagName}
+              </Link>
+            ) : (
+              tagName
+            )}
           </li>
         );
       })}

--- a/components/organisms/Header/Subnavigation.js
+++ b/components/organisms/Header/Subnavigation.js
@@ -53,6 +53,7 @@ export default function Subnavigation({
                 className={`${baseClassName}__link`}
                 tabIndex={active ? 0 : -1}
                 onClick={close}
+                prefetch={false}
               >
                 {title}
               </Link>


### PR DESCRIPTION
Disables prefetch on the navigation menus. Prefetch is ok for the mobile menu, where it's not initiated til the menu slides open, but on desktop the menu is considered always in viewport and all top level items are prefetched.