### PR TITLE
build: parameterize RSC caching

### DIFF
--- a/env.ts
+++ b/env.ts
@@ -1,6 +1,11 @@
 import { createEnv } from "@t3-oss/env-nextjs";
 import { z } from "zod";
 
+const COERCED_BOOLEAN = z
+  .string()
+  // transform to boolean using preferred coercion logic
+  .transform((s) => s !== "false" && s !== "0");
+
 export const env = createEnv({
   emptyStringAsUndefined: true,
   shared: {
@@ -10,17 +15,24 @@ export const env = createEnv({
       .default("test"),
   },
   server: {
+    /** secret that Bing checks during IndexNow requests */
     BING_INDEXNOW_KEY: z.string().min(1).optional(),
     CANTO_BASE_URL: z.string().url(),
     CLOUD_ENV: z.enum(["PROD", "INT", "DEV"]).default("DEV"),
+    /** secret for revalidating pages */
     CRAFT_REVALIDATE_SECRET_TOKEN: z.string().min(1),
+    /** secret for initializing preview sessions */
     CRAFT_SECRET_TOKEN: z.string().min(1),
+    /** secret for Google OAuth */
     GOOGLE_APP_SECRET: z.string().min(1),
     SKYVIEWER_BASE_URL: z.string().url(),
+    /** defines the revalidation time for asset pages retrieved from NOIRLab on the Next server */
     NOIRLAB_REVALIDATE: z.coerce
       .number()
       .min(1)
       .catch(60 * 5),
+    /** if enabled, will add a forced Cache-Control header to RSC responses */
+    NEXT_RSC_CACHE_CONTROL: COERCED_BOOLEAN.optional().default("true"),
   },
   client: {
     NEXT_PUBLIC_API_URL: z.string().url(),
@@ -32,11 +44,7 @@ export const env = createEnv({
     NEXT_PUBLIC_NOIRLAB_BASE_URL: z.string().url(),
 
     NEXT_PUBLIC_PLAUSIBLE_DOMAIN: z.string().min(1).optional(),
-    NEXT_PUBLIC_SURVEY_SPARROW: z
-      .enum(["true", "false"])
-      .transform((v) => v === "true")
-      .optional()
-      .default("false"),
+    NEXT_PUBLIC_SURVEY_SPARROW: COERCED_BOOLEAN.optional().default("false"),
   },
   // For Next.js >= 13.4.4, you only need to destructure client variables:
   experimental__runtimeEnv: {


### PR DESCRIPTION
Adds `NEXT_RSC_CACHE_CONTROL` to env.ts, and outputs its status as a custom header `x-rsc-cache-enabled`