### PR TITLE
fix: fixed copy-url in gallery asset details page

### DIFF
--- a/app/[locale]/gallery/collections/[gallery]/[asset]/page.tsx
+++ b/app/[locale]/gallery/collections/[gallery]/[asset]/page.tsx
@@ -129,7 +129,7 @@ const GalleryAsset: FunctionComponent<GalleryAssetProps> = async ({
           <CantoDownload directUrlOriginal={directUrlOriginal} />
           <SharePopup
             title={name}
-            url={`gallery/${gallery}/${id}`}
+            url={`gallery/collections/${gallery}/${id}`}
             file={
               scheme === "image"
                 ? {


### PR DESCRIPTION
fix: fixed copy-url in gallery asset details page