### PR TITLE
feat: added sort by title to rubin basics

### DIFF
--- a/lib/api/entries.js
+++ b/lib/api/entries.js
@@ -123,7 +123,7 @@ export function useDataList({
         break;
       case "rubinBasics":
         theSection = section;
-        theOrderBy = "date desc";
+        theOrderBy = "title asc";
         query = gql`
           ${rubinBasicsPostFragment}
           ${dataListQueryify(`...rubinBasicsPostFragment`)}


### PR DESCRIPTION
The date, date published, and date created fields aren't visible for the Rubin Basics, and so to sort by data could confuse visitors to the Rubin basics feed page. Rather than date, the content team would like to sort by the `title` field alphabetically.