### PR TITLE
feat: added `LocaleContextInfo` widget

### DIFF
--- a/components/layout/SummitStatus/WidgetContainer/index.js
+++ b/components/layout/SummitStatus/WidgetContainer/index.js
@@ -1,13 +1,22 @@
 import * as Styled from "./styles";
 import PropTypes from "prop-types";
+import LocaleContextInfoBar from "@/components/molecules/LocaleContextInfoBar";
+import { useSummitData } from "@/contexts/SummitData";
 
 const WidgetContainer = ({ children }) => {
+  const {
+    localeContextInfo: { time, date, location },
+  } = useSummitData();
+
   return (
-    <Styled.WidgetContainer>
-      <Styled.HeaderText>Rubin summit status dashboard</Styled.HeaderText>
-      {children}
-      <Styled.FooterText>See more summit status widgets!</Styled.FooterText>
-    </Styled.WidgetContainer>
+    <Styled.Wrapper>
+      <LocaleContextInfoBar time={time} date={date} location={location} />
+      <Styled.WidgetContainer>
+        <Styled.HeaderText>Rubin summit status dashboard</Styled.HeaderText>
+        {children}
+        <Styled.FooterText>See more summit status widgets!</Styled.FooterText>
+      </Styled.WidgetContainer>
+    </Styled.Wrapper>
   );
 };
 WidgetContainer.displayName = "Layout.WidgetContainer";

--- a/components/layout/SummitStatus/WidgetContainer/styles.js
+++ b/components/layout/SummitStatus/WidgetContainer/styles.js
@@ -1,13 +1,15 @@
 import styled from "styled-components";
+import { token } from "@/styles/globalStyles";
 
 export const WidgetContainer = styled.div`
-  width: fit-content;
   padding: 15px 20px;
-  margin: 0px 50px;
-  margin: 0px auto;
   color: #fff;
-  background-color: black;
+  background-color: none;
   border-radius: 10px;
+
+  @media screen and (min-width: ${token("BREAK_DESKTOP_SMALL")}) {
+    background-color: black;
+  }
 `;
 
 export const HeaderText = styled.p`
@@ -18,4 +20,13 @@ export const FooterText = styled.p`
   margin: 20px 0px 0px;
   font-size: 70%;
   text-align: center;
+`;
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  margin-inline: auto;
 `;

--- a/components/layout/SummitStatus/WidgetGrid/index.js
+++ b/components/layout/SummitStatus/WidgetGrid/index.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 
 const WidgetGrid = ({ gridCount, children }) => {
   return (
-    <Styled.WidgetGrid gridCount={gridCount}>{children}</Styled.WidgetGrid>
+    <Styled.WidgetGrid gridcount={gridCount}>{children}</Styled.WidgetGrid>
   );
 };
 

--- a/components/layout/SummitStatus/WidgetGrid/styles.js
+++ b/components/layout/SummitStatus/WidgetGrid/styles.js
@@ -3,7 +3,7 @@ import styled from "styled-components";
 
 export const WidgetGrid = styled.div`
   --widget-row-gap: var(--PADDING_SMALL, 20px);
-  --widget-columns: ${(props) => (props.gridCount > 1 ? 2 : 1)};
+  --widget-columns: ${(props) => (props.gridcount > 1 ? 2 : 1)};
 
   display: inline-grid;
   grid-template-columns: repeat(var(--widget-columns), 1fr);
@@ -18,7 +18,7 @@ export const WidgetGrid = styled.div`
   }
 
   @media screen and (min-width: ${token("BREAK_DESKTOP_SMALL")}) {
-    --widget-columns: ${(props) => props.gridCount};
+    --widget-columns: ${(props) => props.gridcount};
 
     grid-template-columns: none;
     grid-auto-columns: calc(100vw / 7);

--- a/components/molecules/LocaleContextInfoBar/index.tsx
+++ b/components/molecules/LocaleContextInfoBar/index.tsx
@@ -1,0 +1,42 @@
+import UniqueIconComposer from "@/components/svg/UniqueIconComposer";
+import styles from "./styles.module.css";
+import PropTypes from "prop-types";
+
+const LocaleContextInfoBar = ({ time, date, location }) => {
+  // Show if there is at least a date or time, and only if location is defined
+  if ((time === undefined && date === undefined) || location === undefined) {
+    return <></>;
+  }
+  return (
+    <div className={styles.container}>
+      {time && (
+        <span className={styles.localeText}>
+          <UniqueIconComposer className={styles.icon} icon="time" size={15} />
+          {time}
+        </span>
+      )}
+      {date && (
+        <span className={styles.localeText}>
+          <UniqueIconComposer
+            className={styles.icon}
+            icon="calendar"
+            size={15}
+          />
+          {date}
+        </span>
+      )}
+      <span className={styles.localeText}>
+        <UniqueIconComposer className={styles.icon} icon="pin" size={15} />
+        {location}
+      </span>
+    </div>
+  );
+};
+
+LocaleContextInfoBar.propTypes = {
+  time: PropTypes.string,
+  date: PropTypes.string,
+  location: PropTypes.string,
+};
+
+export default LocaleContextInfoBar;

--- a/components/molecules/LocaleContextInfoBar/styles.module.css
+++ b/components/molecules/LocaleContextInfoBar/styles.module.css
@@ -1,0 +1,33 @@
+.localeText {
+    color: #000;
+    font-size: clamp(0.5rem, 1rem, 2rem);
+    vertical-align: middle;
+
+    @media screen and (min-width: 1130px) {
+        width: fit-content;
+        font-size: 13px;
+        margin: 0px 10px 0px 0px;
+    }
+}
+
+.container {
+    background-color: #30dfe3;
+    display: flex;
+    align-self: flex-start;
+    justify-content: space-around;
+    padding: 2px 10px;
+    border-radius: 5px;
+    width: 100%;
+    
+    margin: 0px 0px 20px;
+
+    @media screen and (min-width: 1130px) {
+        width: fit-content;
+        justify-content:  center;
+    }
+}
+
+.icon {
+    margin: 0px 5px 0px 0px;
+    vertical-align: middle;
+}

--- a/contexts/SummitData.js
+++ b/contexts/SummitData.js
@@ -32,6 +32,30 @@ export const SummitDataProvider = ({ children }) => {
       summitData.current.dewPoint = 1.0; // temporary code just for demoing/unblocking us
     }
   }
+  const dateTime = Object.fromEntries(
+    new Intl.DateTimeFormat("en-US", {
+      timeZone: "America/Santiago",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+    })
+      .formatToParts(new Date())
+      .map((p) => [p.type, p.value])
+  );
+
+  const time = `${dateTime.hour}:${dateTime.minute} hrs`;
+  const date = `${dateTime.year}-${dateTime.month}-${dateTime.day}`;
+
+  const localeContextInfo = {
+    time,
+    date,
+    location: "Chile",
+  };
+
   const value = useMemo(
     () => ({
       summitData,
@@ -42,6 +66,11 @@ export const SummitDataProvider = ({ children }) => {
         hasura: isLoading,
         astroweather: astroweatherIsLoading,
       },
+      localeContextInfo: {
+        time,
+        date,
+        location: "Chile",
+      },
     }),
     [
       summitData,
@@ -51,6 +80,7 @@ export const SummitDataProvider = ({ children }) => {
       isError,
       astroweatherIsLoading,
       astroweatherIsError,
+      localeContextInfo,
     ]
   );
 


### PR DESCRIPTION
This adds the teal location info bar for the homepage Summit Status Dashboard compact view. It's designed with mobile-first styling and adjusts for desktop.

To test:

1. Ensure at least one widget is added to the Summit Status Compact View content block
2. Load the homepage
3. Adjust the viewport width to see change in styling
4. Add more widgets to the Summit Status Compact View content block to simulate more widgets
5. Manually change the `gridCount` prop that gets passed to the `WidgetGrid` to the number of widgets added in the compact view component
6. Assess desktop and mobile styling