### PR TITLE
Er add survey progress widget

### DIFF
--- a/components/content-blocks/SummitStatusCompactView/index.tsx
+++ b/components/content-blocks/SummitStatusCompactView/index.tsx
@@ -7,6 +7,7 @@ import { SummitDataProvider } from "@/contexts/SummitData";
 import CameraFeeds from "@/components/dynamic/SummitData/CameraFeeds";
 import DomeStatus from "@/components/dynamic/SummitData/DomeStatus";
 import ExposureCount from "@/components/dynamic/SummitData/ExposureCount";
+import SurveyProgress from "@/components/dynamic/SummitData/SurveyProgress";
 import WidgetGrid from "@/components/layout/SummitStatus/WidgetGrid";
 import WidgetContainer from "@/components/layout/SummitStatus/WidgetContainer";
 
@@ -45,6 +46,7 @@ const SummitStatusCompactView: FC<SummitStatusCompactViewProps> = (props) => {
               {allSkyImage && <CameraFeeds isCompact={true} />}
               {domeStatus && <DomeStatus isCompact={true} />}
               {exposureCount && <ExposureCount isCompact={true} />}
+              {SurveyProgress && <SurveyProgress />}
             </WidgetGrid>
           </WidgetContainer>
         </SummitDataProvider>

--- a/components/dynamic/SummitData/SurveyProgress/index.tsx
+++ b/components/dynamic/SummitData/SurveyProgress/index.tsx
@@ -1,0 +1,51 @@
+import { useSummitData } from "@/contexts/SummitData";
+import { useTranslation } from "react-i18next";
+import Loader from "@/components/atomic/Loader";
+import WidgetSection from "@/components/layout/SummitStatus/WidgetSection";
+import styles from "./styles.module.css";
+import clsx from "clsx";
+import { ProgressRadial } from "@rubin-epo/epo-react-lib";
+
+const SurveyProgress = () => {
+  const { t } = useTranslation();
+  const {
+    summitData: { surveyProgress },
+    isLoading,
+  } = useSummitData();
+
+  const progressFormatter = (value) =>
+    Intl.NumberFormat("en-US", {
+      style: "percent",
+      maximumFractionDigits: 1,
+    }).format(value / 100);
+
+  const stillLoading = isLoading.hasura === undefined || isLoading.hasura;
+
+  return (
+    <WidgetSection
+      isCollapsible={false}
+      title={t("summit_dashboard.sections.survey_progress.title")}
+      caption={t("summit_dashboard.sections.survey_progress.caption")}
+    >
+      <div
+        className={clsx(styles.widgetBackground, styles.condensedBackground)}
+      >
+        {stillLoading ? (
+          <Loader isVisible={true} />
+        ) : (
+          <ProgressRadial
+            value={surveyProgress}
+            role={"progressbar"}
+            min={0}
+            max={100}
+            markerFormatter={progressFormatter}
+          />
+        )}
+      </div>
+    </WidgetSection>
+  );
+};
+
+SurveyProgress.displayName = "Dynamic.SurveyProgress";
+
+export default SurveyProgress;

--- a/components/dynamic/SummitData/SurveyProgress/styles.module.css
+++ b/components/dynamic/SummitData/SurveyProgress/styles.module.css
@@ -1,0 +1,31 @@
+.surveyProgressBackground {
+    width: 100%;
+}
+
+.widgetBackground {
+  --widget-background-color: "#313333";
+  --widget-padding: clamp(5px, -2.5px + 0.977vw, 10px);
+
+  display: flex;
+  flex-direction: column;
+  place-self: center center;
+  align-items: center;
+  justify-content: space-between;
+  width: 65%;
+  padding: var(--widget-padding);
+  font-size: 0.75rem;
+  background-color: var(--widget-background-color);
+  border-radius: calc(var(--widget-padding) / 2);
+}
+
+
+.condensedBackground {
+  /* To-do: configure CSS processor to use `composes` */
+  /* composes: widgetBackground; */
+  display: grid;
+  grid-template-rows: 100%;
+  grid-template-columns: repeat(1, 1fr);
+  grid-column: 1 / -1;
+  gap: var(--widget-padding);
+  place-items: center center;
+}

--- a/contexts/SummitData.js
+++ b/contexts/SummitData.js
@@ -29,6 +29,7 @@ export const SummitDataProvider = ({ children }) => {
       hourly: data.summitHourlyData.hourly,
       domeStatus: data.nightlyDigest.nightlyDigest.domeStatus,
       exposureCount: data.nightlyDigest.nightlyDigest.exposureCount,
+      surveyProgress: data.nightlyDigest.nightlyDigest.surveyProgress,
     };
     if (summitData.current.dewPoint === null) {
       summitData.current.dewPoint = 1.0; // temporary code just for demoing/unblocking us

--- a/lib/api/summitData.js
+++ b/lib/api/summitData.js
@@ -22,6 +22,7 @@ export const hasuraQuery = gql`
       nightlyDigest {
         exposureCount: exposure_count
         domeStatus: dome_open
+        surveyProgress: survey_progress
       }
     }
     summitCurrentData: summitDataCurrent {

--- a/lib/i18n/localeStrings/en/translation.json
+++ b/lib/i18n/localeStrings/en/translation.json
@@ -438,6 +438,10 @@
       "exposure_count": {
         "title": "Tonight, Rubin has taken",
         "caption": "Images"
+      },
+      "survey_progress": {
+        "title": "Survey Progress",
+        "caption": "of the 10-year survey"
       }
     },
     "weather": {

--- a/lib/i18n/localeStrings/es/translation.json
+++ b/lib/i18n/localeStrings/es/translation.json
@@ -395,6 +395,24 @@
       "south_abbr": "S",
       "east_abbr": "E",
       "west_abbr": "O"
+    },
+    "sections": {
+      "all_sky_image": {
+        "title": "All-Sky Camera"
+      },
+      "dome_status": {
+        "title": "Dome Status",
+        "status_open": "Open",
+        "status_closed": "Closed"
+      },
+      "exposure_count": {
+        "title": "Tonight, Rubin has taken",
+        "caption": "Images"
+      },
+      "survey_progress": {
+        "title": "Survey Progress",
+        "caption": "of the 10-year survey"
+      }
     }
   },
   "first_look": {


### PR DESCRIPTION
To test:

1. Enable `Survey Progress` setting in `Summit Status Compact View` content block
2. Start up Next.js dev server
3. Assess `SurveyProgress` widget looks as expected in desktop view
4. Assess `SurveyProgress` widget looks as expected in mobile view