### PR TITLE
feat: add origin inspection and CORS header to api/revalidate

### DIFF
--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -3,30 +3,54 @@ import { env } from "@/env";
 import revalidate from "@/services/revalidation";
 
 const REVALIDATE_SECRET_TOKEN = env.CRAFT_REVALIDATE_SECRET_TOKEN;
+// This RegEx pattern should match any authenticated URL Google generates for the on-demand revalidation tool
+// the known pattern is a GUID followed by '-apidata.googleusercontent.com'
+const GOOGLE_AUTHENTICATED_URL_PATTERN =
+  /^https:\/\/[a-zA-Z0-9]+-apidata\.googleusercontent\.com$/;
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
   const uri = request.nextUrl.searchParams.get("uri");
   const secret = request.nextUrl.searchParams.get("secret");
+  const origin = request.headers.get("origin");
 
   console.info(
     `[CLIENT_REVALIDATE_STATUS] Inside of revalidate endpoint in /app/api/revalidate for: ${uri}`
   );
+
+  if (origin && !origin.match(GOOGLE_AUTHENTICATED_URL_PATTERN)) {
+    console.info(
+      `[CLIENT_REVALIDATE_STATUS] Origin Header '${origin}' does not match accepted header pattern. Request rejected.`
+    );
+    const response = NextResponse.json({
+      revalidated: false,
+      now: Date.now(),
+      message: "Bad origin",
+    });
+    return response;
+  }
+
   if (!uri) {
     console.info("[CLIENT_REVALIDATE_STATUS] No URI, returning");
-    return NextResponse.json({
+    const response = NextResponse.json({
       revalidated: false,
       now: Date.now(),
       message: "Missing path to revalidate",
     });
+
+    if (origin) response.headers.set("Access-Control-Allow-Origin", origin);
+    return response;
   }
 
   if (secret !== REVALIDATE_SECRET_TOKEN) {
     console.info("[CLIENT_REVALIDATE_STATUS] Revalidate secret is incorrect");
-    return NextResponse.json({
+    const response = NextResponse.json({
       revalidated: false,
       now: Date.now(),
       message: "Invalid token",
     });
+
+    if (origin) response.headers.set("Access-Control-Allow-Origin", origin);
+    return response;
   }
 
   if (uri) {
@@ -37,7 +61,13 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     );
     console.info(debugOutput);
 
-    return NextResponse.json({ revalidated: true, now: Date.now() });
+    const response = NextResponse.json({
+      revalidated: true,
+      now: Date.now(),
+    });
+
+    if (origin) response.headers.set("Access-Control-Allow-Origin", origin);
+    return response;
   }
 
   return NextResponse.json({


### PR DESCRIPTION
resolves #1055 

This change updates the cache revalidation api endpoint to attempt to get the origin value from the request header if it passes the guard conditional (is present and matches the GCP URL pattern) it proceeds as normal while adding the `Access-Control-Allow-Origin` header to the response if there is a passing origin.

Notes:
- Setting the `Access-Control-Allow-Origin` header only depends on the origin not being `null` because we would have returned in the guard conditional if it didn't match the allowed pattern.
- There is repeated code for conditionally setting the `Access-Control-Allow-Origin` header in each of the original guards. The response preparation could be abstracted into a helper function but that doesn't seem worth the time trade off right now.

To test:

- Start rubin-obs-client locally
- Modify the `REVALIDATION_ROOT` of the GCP hosted revalidation tool so it points at your localhost
  - It needs to be tested from GCP because loading the local HTML file in your browser will result in an origin of "null"
- Monitor the browsers console as you make a revalidation request (any path will do)
- Make a GET request to `localhost:3000/api/metrics/cache` to verify the revalidation is now listed in the `tagsManifest` object

These testing steps should be repeated against the develop environment once this PR is merged, just to be sure.