### PR TITLE
fix: allow images in NOIRLab press releases

### DIFF
--- a/components/templates/NewsPage/index.tsx
+++ b/components/templates/NewsPage/index.tsx
@@ -14,7 +14,7 @@ const sanitize = (dirty: string | undefined) => {
       `${env.NEXT_PUBLIC_NOIRLAB_BASE_URL}`
     );
     const sanitizeOptions: IOptions = {
-      allowedTags: [...defaults.allowedTags, "iframe"],
+      allowedTags: [...defaults.allowedTags, "iframe", "img"],
       allowedAttributes: {
         ...defaults.allowedAttributes,
         iframe: ["src", "style", "width", "height", "allowfullscreen"],


### PR DESCRIPTION
This latest bug was reported by the content team after the most recent collaborative NOIRLab press release. The fix was simple - allowing for image tags in the main content area of the press release. We need to handle whitelisting tags on a case-by-case basis as we are ingesting content via NOIRLab's Django API and the field that is fed into the main content area contains HTML. We use the `sanitize-html` NPM package to do this and it is extendable as this update shows.