### PR TITLE
fix: show daytime weather SVGs between 7am-7pm CST

### DIFF
--- a/contexts/SummitData.js
+++ b/contexts/SummitData.js
@@ -323,7 +323,9 @@ export const SummitDataProvider = ({ children }) => {
 
     // Switch to using nighttime SVG at 7pm
     const svgName =
-      dateTime.hour < "19" ? currentWeather.daySVG : currentWeather.nightSVG;
+      dateTime.hour > "7" && dateTime.hour < "19"
+        ? currentWeather.daySVG
+        : currentWeather.nightSVG;
     const weatherDescription = currentWeather.description;
 
     currentWeatherArtifacts = {


### PR DESCRIPTION
I hardcoded the conditional for selecting the day vs night SVGs to switch at 7am and 7pm. If we want a smarter switch, the Meteoblue API [provides sunset and sunrise times](https://docs.meteoblue.com/en/weather-apis/forecast-api/overview#:~:text=Sun%20%26%20moon,moon%20and%20sun), but this might run up our credit usage. Alternatively, I could look into doing the [calculation](https://en.wikipedia.org/wiki/Sunrise_equation) myself and add it as a utility function, or see if there's a package that provides the function already.