### PR TITLE
fix: fix query parms for skyviewer embed

### DIFF
--- a/components/content-blocks/Skyviewer/index.tsx
+++ b/components/content-blocks/Skyviewer/index.tsx
@@ -51,8 +51,13 @@ const SkyviewerBlock: FC<SkyviewerProps> = ({ locale, ...props }) => {
 
   const { ra, dec, fov, fullWidth, backgroundColor, embedTitle } = data;
 
-  const params = new URLSearchParams({ ra, dec, fov });
-  const path = addLocaleUriSegment(locale, `embed?${params.toString()}`);
+  const params = new URLSearchParams({ target: `${ra}+${dec}`, fov });
+
+  // Create a path with locale and query params and swap pesky encoded '+' value with the actual value
+  const path = addLocaleUriSegment(
+    locale,
+    `embed?${params.toString()}`
+  ).replace("%2B", "+");
   const src = new URL(path, env.SKYVIEWER_BASE_URL);
   const allowed = [
     "fullscreen",


### PR DESCRIPTION
The Skyviewer embed requires `fov` and `target` query params to focus where the embed. Previously, `ra` and `dec` were being passed in which was causing the survey to focus on it's default starting `ra` and `dec`. The solution was to concatenate `ra` and `dec` into the `target` query param.

Because the `URLSearchParams` web API will automatically encode special characters there is a `.replace()` to add back the `+`. Unfortunately the `URLSearchParams.toString()` method doesn't offer an option to not encode.

Perhaps we could modify the Skyviewer client embed page to decode URL encoded characters, but that will be addressed in a separate issue - should we decide to do so.