### PR TITLE
fix: added spanish translation for wildife spotlight title

### DIFF
--- a/lib/i18n/localeStrings/es/translation.json
+++ b/lib/i18n/localeStrings/es/translation.json
@@ -500,7 +500,7 @@
         "title": "Puesta de Sol y Amanecer"
       },
       "wildlife_spotlight" : {
-        "title": "Wildlife Spotlight"
+        "title": "Especies Destacadas"
       }
     },
     "weather": {


### PR DESCRIPTION
Resolves #1110 

Adds a Spanish translation for the title of the Wildlife Spotlight widget

To test, spin up the client with the Rubin Dash added to the homepage. Switch the locale to `es` and confirm the widget's title changes from "Wildlife Spotlight" to "Especies Destacadas".

<img width="213" height="293" alt="image" src="https://github.com/user-attachments/assets/aefea723-ac2d-4a9f-ac3b-56ea022df7aa" />


