### PR TITLE
fix: updated wildlife spotlight image to take up full widget section …

### DIFF
--- a/components/dynamic/SummitData/SunsetSunrise/styles.module.css
+++ b/components/dynamic/SummitData/SunsetSunrise/styles.module.css
@@ -42,7 +42,7 @@
   width: 100%;
   height: 100%;
   align-items: center;
-  justify-content: space-between;
+  justify-content: space-center;
 }
 
 .sunsetSunriseContainer > div {

--- a/components/molecules/GallerySpotlight/styles.module.css
+++ b/components/molecules/GallerySpotlight/styles.module.css
@@ -1,5 +1,5 @@
 .container {
-  width: auto;
+  width: 100%;
   height: 100%;
   align-items: center;
 }


### PR DESCRIPTION
Fixes the image sizing in the Wildlife Spotlight image so the image take sup a greater width.

Before:
<img width="111" height="122" alt="image" src="https://github.com/user-attachments/assets/c5df3476-910f-4064-8d3e-a67f674173da" />

After:
<img width="111" height="122" alt="image" src="https://github.com/user-attachments/assets/985f46a0-4fba-4978-abf1-23b4621ea3c6" />
