### PR TITLE
fix: bug preventing the nighttime weather SVGs from being used between 7p - 7a

### DIFF
--- a/contexts/SummitData.js
+++ b/contexts/SummitData.js
@@ -326,7 +326,8 @@ export const SummitDataProvider = ({ children }) => {
     let svgName;
     let alertsTitle;
     let exposuresTitle;
-    if (dateTime.hour < 7 && dateTime.hour > 19) {
+    // If the hour is before 7:00a OR after 7p
+    if (dateTime.hour < 7 || dateTime.hour >= 19) {
       svgName = currentWeather.nightSVG;
       alertsTitle = t("summit_dashboard.sections.alert_count.title.night");
       exposuresTitle = t(


### PR DESCRIPTION
Resolves #1125

This PR is a hotfix for the bug preventing the nighttime SVGs from being used after 7p and before 7a.

The conditional at [contexts/SummitData.js:L329-L339](https://github.com/lsst-epo/rubin-obs-client/blob/883230ddbf9c8e4c99496327e12e3673e13a7287/contexts/SummitData.js#L329-L339) intended to show the nighttime weather SVG if the hour is before 7am and after 7pm (18:00) but using the `&&` operator causes this to always return false because a number cannot be less than 7 and greater than 18 at the same time.

Current:
```
    if (dateTime.hour < 7 && dateTime.hour > 19) {
      // Nighttime
    } else {
      // day
    }
```

Fix: An `||` or actually gives us the condition we want. We can further improve it by checking if `dateTime.hour >= 19` so it switches to nighttime _during_ the 7pm hour.

```
    if (dateTime.hour < 7 || dateTime.hour >= 19) {
      // Nighttime
    } else {
      // day
    }
```